### PR TITLE
Fix TokenizingTextBox header to behave like normal text control headers

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
@@ -68,6 +68,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <ContentPresenter Content="{TemplateBinding Header}"
@@ -108,12 +109,17 @@
                           ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
 
                 <ItemsPresenter Padding="{TemplateBinding Padding}"
-                                Margin="{StaticResource TokenizingTextBoxPresenterMargin}"
-                                Footer="{TemplateBinding Footer}"
-                                FooterTemplate="{TemplateBinding FooterTemplate}"
-                                FooterTransitions="{TemplateBinding FooterTransitions}" />
+                                Margin="{StaticResource TokenizingTextBoxPresenterMargin}"/>
             </ScrollViewer>
 
+            <ContentPresenter Grid.Row="2"
+                              Content="{TemplateBinding Footer}"
+                              ContentTemplate="{TemplateBinding FooterTemplate}"
+                              Transitions="{TemplateBinding FooterTransitions}"
+                              FontWeight="Normal"
+                              TextWrapping="Wrap"
+                              VerticalAlignment="Top" />
+            
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Disabled">

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
@@ -119,14 +119,14 @@
                     <VisualState x:Name="Disabled">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                               Storyboard.TargetProperty="Background">
+                                                           Storyboard.TargetProperty="Background">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                            Value="{ThemeResource TextControlBackgroundDisabled}" />
+                                                        Value="{ThemeResource TextControlBackgroundDisabled}" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                               Storyboard.TargetProperty="BorderBrush">
+                                                           Storyboard.TargetProperty="BorderBrush">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                            Value="{ThemeResource TextControlBorderBrushDisabled}" />
+                                                        Value="{ThemeResource TextControlBorderBrushDisabled}" />
                             </ObjectAnimationUsingKeyFrames>
 
                         </Storyboard>
@@ -135,14 +135,14 @@
                     <VisualState x:Name="PointerOver">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                               Storyboard.TargetProperty="BorderBrush">
+                                                           Storyboard.TargetProperty="BorderBrush">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                            Value="{ThemeResource TextControlBorderBrushPointerOver}" />
+                                                        Value="{ThemeResource TextControlBorderBrushPointerOver}" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                               Storyboard.TargetProperty="Background">
+                                                           Storyboard.TargetProperty="Background">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                            Value="{ThemeResource TextControlBackgroundPointerOver}" />
+                                                        Value="{ThemeResource TextControlBackgroundPointerOver}" />
                             </ObjectAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
@@ -111,7 +111,7 @@
                                 Margin="{StaticResource TokenizingTextBoxPresenterMargin}"
                                 Footer="{TemplateBinding Footer}"
                                 FooterTemplate="{TemplateBinding FooterTemplate}"
-                                FooterTransitions="{TemplateBinding FooterTransitions}"/>
+                                FooterTransitions="{TemplateBinding FooterTransitions}" />
             </ScrollViewer>
 
             <VisualStateManager.VisualStateGroups>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.xaml
@@ -65,18 +65,34 @@
     <ControlTemplate x:Key="TokenizingTextBoxTemplate"
                      TargetType="controls:TokenizingTextBox">
         <Grid Name="RootPanel">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <ContentPresenter Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              Transitions="{TemplateBinding HeaderTransitions}"
+                              FontWeight="Normal"
+                              Foreground="{ThemeResource TextControlHeaderForeground}"
+                              Margin="{ThemeResource TextBoxTopHeaderMargin}"
+                              TextWrapping="Wrap"
+                              VerticalAlignment="Top" />
             <Border x:Name="BackgroundVisual"
+                    Grid.Row="1"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}" />
 
             <Border x:Name="FocusVisual"
+                    Grid.Row="1"
                     Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
                     BorderBrush="{ThemeResource TextControlBorderBrushFocused}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     Opacity="0" /> <!-- Background in WinUI is TextControlBackgroundFocused, but that uses a different resource in WinUI than system -->
 
             <ScrollViewer x:Name="ScrollViewer"
+                          Grid.Row="1"
                           AutomationProperties.AccessibilityView="Raw"
                           BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
                           HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -95,10 +111,7 @@
                                 Margin="{StaticResource TokenizingTextBoxPresenterMargin}"
                                 Footer="{TemplateBinding Footer}"
                                 FooterTemplate="{TemplateBinding FooterTemplate}"
-                                FooterTransitions="{TemplateBinding FooterTransitions}"
-                                Header="{TemplateBinding Header}"
-                                HeaderTemplate="{TemplateBinding HeaderTemplate}"
-                                HeaderTransitions="{TemplateBinding HeaderTransitions}" />
+                                FooterTransitions="{TemplateBinding FooterTransitions}"/>
             </ScrollViewer>
 
             <VisualStateManager.VisualStateGroups>
@@ -106,14 +119,14 @@
                     <VisualState x:Name="Disabled">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                           Storyboard.TargetProperty="Background">
+                                                               Storyboard.TargetProperty="Background">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                        Value="{ThemeResource TextControlBackgroundDisabled}" />
+                                                            Value="{ThemeResource TextControlBackgroundDisabled}" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                           Storyboard.TargetProperty="BorderBrush">
+                                                               Storyboard.TargetProperty="BorderBrush">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                        Value="{ThemeResource TextControlBorderBrushDisabled}" />
+                                                            Value="{ThemeResource TextControlBorderBrushDisabled}" />
                             </ObjectAnimationUsingKeyFrames>
 
                         </Storyboard>
@@ -122,14 +135,14 @@
                     <VisualState x:Name="PointerOver">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                           Storyboard.TargetProperty="BorderBrush">
+                                                               Storyboard.TargetProperty="BorderBrush">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                        Value="{ThemeResource TextControlBorderBrushPointerOver}" />
+                                                            Value="{ThemeResource TextControlBorderBrushPointerOver}" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundVisual"
-                                                           Storyboard.TargetProperty="Background">
+                                                               Storyboard.TargetProperty="Background">
                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                        Value="{ThemeResource TextControlBackgroundPointerOver}" />
+                                                            Value="{ThemeResource TextControlBackgroundPointerOver}" />
                             </ObjectAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>


### PR DESCRIPTION
## Fixes #4096 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Header rendered inside the TokenizingTextBox

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->

Header now renders above the TokenizingTextBox input area.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
Also took the liberty to add the properties for the header presenter that are also present for the TextBox header presenter.