### PR TITLE
Fix most build warnings from the projects

### DIFF
--- a/UITests/UITests.Tests.Shared/Controls/GridSplitterTest.cs
+++ b/UITests/UITests.Tests.Shared/Controls/GridSplitterTest.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Windows.Apps.Test.Foundation;
-using Microsoft.Windows.Apps.Test.Foundation.Controls;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
-using System.Linq;
-using System.Threading.Tasks;
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Windows.Apps.Test.Foundation;
+using Microsoft.Windows.Apps.Test.Foundation.Controls;
 
 #if USING_TAEF
 using WEX.Logging.Interop;
@@ -20,9 +19,11 @@ using WEX.TestExecution.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+
 namespace UITests.Tests
 {
-
     [TestClass]
     public class GridSplitterTest : UITestBase
     {

--- a/UITests/UITests.Tests.Shared/Controls/RangeSelectorTest.cs
+++ b/UITests/UITests.Tests.Shared/Controls/RangeSelectorTest.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 
 #if USING_TAEF
 using WEX.Logging.Interop;
@@ -14,9 +12,11 @@ using WEX.TestExecution.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+
 namespace UITests.Tests
 {
-
     [TestClass]
     public class RangeSelectorTest : UITestBase
     {

--- a/UITests/UITests.Tests.Shared/Controls/RichSuggestBoxTest.cs
+++ b/UITests/UITests.Tests.Shared/Controls/RichSuggestBoxTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Windows.Apps.Test.Automation;
 using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
-using Microsoft.Windows.Apps.Test.Automation;
 
 #if USING_TAEF
 using WEX.Logging.Interop;

--- a/UITests/UITests.Tests.Shared/UITestBase.cs
+++ b/UITests/UITests.Tests.Shared/UITestBase.cs
@@ -6,8 +6,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using System.Threading.Tasks;
 
 #if USING_TAEF
@@ -17,6 +15,9 @@ using WEX.TestExecution.Markup;
 #else
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
+
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 
 namespace UITests.Tests
 {

--- a/UnitTests/UnitTests.HighPerformance.UWP/UnitTests.HighPerformance.UWP.csproj
+++ b/UnitTests/UnitTests.HighPerformance.UWP/UnitTests.HighPerformance.UWP.csproj
@@ -152,6 +152,10 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>5.0.0</Version>
     </PackageReference>
+    <!-- For warnings ILT0010, ILT0005, ILT0003 -->
+    <PackageReference Include="System.Xml.XPath.XmlDocument">
+      <Version>4.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Toolkit.HighPerformance\Microsoft.Toolkit.HighPerformance.csproj">

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -235,7 +235,7 @@ namespace UnitTests.Mvvm
         public partial class ModelWithValueProperty : ObservableObject
         {
             [ObservableProperty]
-            private string value;
+            private string? value;
         }
 
         public partial class ModelWithValuePropertyWithValidation : ObservableValidator
@@ -243,7 +243,7 @@ namespace UnitTests.Mvvm
             [ObservableProperty]
             [Required]
             [MinLength(5)]
-            private string value;
+            private string? value;
         }
     }
 }

--- a/UnitTests/UnitTests.Notifications.UWP/UnitTestApp.xaml.cs
+++ b/UnitTests/UnitTests.Notifications.UWP/UnitTestApp.xaml.cs
@@ -16,6 +16,9 @@ namespace UnitTests.Notifications.UWP
     /// </summary>
     public sealed partial class App : Application
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="App"/> class.
+        /// </summary>
         public App()
         {
             InitializeComponent();

--- a/UnitTests/UnitTests.Shared/.editorconfig
+++ b/UnitTests/UnitTests.Shared/.editorconfig
@@ -1,7 +1,17 @@
-[*.{cs,vb}]
 
-# SA1601: Partial elements should be documented
+# Analyzer Configurations for Unit Test sources
+
+# C# Source Files
+[*.cs]
+
+# A C# partial element is missing a documentation header.
 dotnet_diagnostic.SA1601.severity = none
+
+# The Parameter has no matching param tag in the XML comment.
 dotnet_diagnostic.CS1573.severity = none
+
+# Missing XML comment for publicly visible type or member.
 dotnet_diagnostic.CS1591.severity = none
+
+# The Type parameter has no matching typeparam tag in the XML comment.
 dotnet_diagnostic.CS1712.severity = none


### PR DESCRIPTION
## Partially Fixes #4240

Fix most warnings from the projects! Only warnings left are MVVM from source generators.


## PR Type
What kind of change does this PR introduce?

 - Refactoring (no functional changes)
 - Build/CI changes


## What is the current behavior?

Build produces so many warnings. It is a source of developer's frustration and shame! 😢


## What is the new behavior?

Build now produces less impactful or no warnings at all. Happy CI, Happy Dev! 😎


## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes


## Other information

 - If you're editing this patch tree, please `rebase` on latest `HEAD` and then commit, without updating from the latest `HEAD`.
 - When merging, please update the commit title to PR title instead of the default `Merge pull request #xxxx from repo/branch`, and commit message to either PR message or messages of individual commits. The `auto-merge` bot does this by default.