### PR TITLE
Changed SmoothScrollIntoView method to be truly asynchronous

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml
@@ -71,7 +71,7 @@
                      Margin="0,10,0,0" />
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                 <Ellipse x:Name="ScrollIndicator" Fill="Red" Width="15" Height="15"/>
-                <TextBlock x:Name="ScrollIndicatorTest" Text="Scroll not started" Margin="10,0,0,0"/>
+                <TextBlock x:Name="ScrollIndicatorTest" Text="Not Scrolling" Margin="10,0,0,0"/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml
@@ -35,14 +35,16 @@
         </Grid>
 
         <StackPanel Grid.Column="1" Margin="5,10,10,0" Width="200">
-            <TextBlock Text="Smooth Scroll Settings" FontSize="{StaticResource TextStyleLargeFontSize}" Margin="0,0,0,10"/>
+            <TextBlock Text="Smooth Scroll Settings" FontSize="{StaticResource TextStyleLargeFontSize}"/>
             <TextBox x:Name="IndexInput"
                      Header="Index"
                      InputScope="Number"
-                     Text="100" />
+                     Text="100"
+                     Margin="0,10,0,0" />
             <ComboBox x:Name="ItemPlacementInput"
                       Header="Item Placement"
-                      SelectedIndex="0">
+                      SelectedIndex="0"
+                      Margin="0,10,0,0" >
                 <x:String>Default</x:String>
                 <x:String>Left</x:String>
                 <x:String>Top</x:String>
@@ -52,18 +54,25 @@
             </ComboBox>
             <CheckBox x:Name="DisableAnimationInput"
                       Content="Disable Animation"
-                      IsChecked="False" />
+                      IsChecked="False"
+                      Margin="0,10,0,0" />
             <CheckBox x:Name="ScrollIfVisibileInput"
                       Content="Scroll If Visible"
                       IsChecked="True" />
             <TextBox x:Name="AdditionalHorizontalOffsetInput"
                      Header="Horizontal Offset"
                      InputScope="Number"
-                     Text="0" />
+                     Text="0"
+                     Margin="0,10,0,0" />
             <TextBox x:Name="AdditionalVerticalOffsetInput"
                      Header="Vertical Offset"
                      InputScope="Number"
-                     Text="0" />
+                     Text="0"
+                     Margin="0,10,0,0" />
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <Ellipse x:Name="ScrollIndicator" Fill="Red" Width="15" Height="15"/>
+                <TextBlock x:Name="ScrollIndicatorTest" Text="Scroll not started" Margin="10,0,0,0"/>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
@@ -72,13 +72,13 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             if (isScrolling)
             {
-                ScrollIndicatorTest.Text = "Scroll started";
+                ScrollIndicatorTest.Text = "Scrolling";
                 ScrollIndicator.Fill = new SolidColorBrush(Colors.Green);
             }
             else
             {
                 ScrollIndicator.Fill = new SolidColorBrush(Colors.Red);
-                ScrollIndicatorTest.Text = "Scroll completed";
+                ScrollIndicatorTest.Text = "Not Scolling";
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         private void Load()
         {
-            SampleController.Current.RegisterNewCommand("Start Smooth Scroll", (sender, args) =>
+            SampleController.Current.RegisterNewCommand("Start Smooth Scroll", async (sender, args) =>
             {
                 var index = int.TryParse(IndexInput.Text, out var i) ? i : 0;
                 var itemPlacement = ItemPlacementInput.SelectedItem switch
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 var scrollIfVisibile = ScrollIfVisibileInput.IsChecked ?? true;
                 var additionalHorizontalOffset = int.TryParse(AdditionalHorizontalOffsetInput.Text, out var ho) ? ho : 0;
                 var additionalVerticalOffset = int.TryParse(AdditionalVerticalOffsetInput.Text, out var vo) ? vo : 0;
-                sampleListView.SmoothScrollIntoViewWithIndexAsync(index, itemPlacement, disableAnimation, scrollIfVisibile, additionalHorizontalOffset, additionalVerticalOffset);
+                await sampleListView.SmoothScrollIntoViewWithIndexAsync(index, itemPlacement, disableAnimation, scrollIfVisibile, additionalHorizontalOffset, additionalVerticalOffset);
             });
 
             if (sampleListView != null)

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
@@ -6,9 +6,11 @@ using System;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Microsoft.Toolkit.Uwp.UI;
+using Windows.UI;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
@@ -55,12 +57,28 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 var scrollIfVisibile = ScrollIfVisibileInput.IsChecked ?? true;
                 var additionalHorizontalOffset = int.TryParse(AdditionalHorizontalOffsetInput.Text, out var ho) ? ho : 0;
                 var additionalVerticalOffset = int.TryParse(AdditionalVerticalOffsetInput.Text, out var vo) ? vo : 0;
+                UpdateScrollIndicator(true);
                 await sampleListView.SmoothScrollIntoViewWithIndexAsync(index, itemPlacement, disableAnimation, scrollIfVisibile, additionalHorizontalOffset, additionalVerticalOffset);
+                UpdateScrollIndicator(false);
             });
 
             if (sampleListView != null)
             {
                 sampleListView.ItemsSource = GetOddEvenSource(500);
+            }
+        }
+
+        private void UpdateScrollIndicator(bool isScrolling)
+        {
+            if (isScrolling)
+            {
+                ScrollIndicatorTest.Text = "Scroll started";
+                ScrollIndicator.Fill = new SolidColorBrush(Colors.Green);
+            }
+            else
+            {
+                ScrollIndicator.Fill = new SolidColorBrush(Colors.Red);
+                ScrollIndicatorTest.Text = "Scroll completed";
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -201,6 +201,9 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
+            horizontalOffset = horizontalOffset > scrollViewer.ScrollableWidth ? scrollViewer.ScrollableWidth : horizontalOffset;
+            verticalOffset = verticalOffset > scrollViewer.ScrollableHeight ? scrollViewer.ScrollableHeight : verticalOffset;
+
             // MUST check this and return immediately, otherwise this async task will never complete because ViewChanged event won't get triggered
             if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)
             {

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -201,8 +201,23 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
-            horizontalOffset = horizontalOffset > scrollViewer.ScrollableWidth ? scrollViewer.ScrollableWidth : horizontalOffset;
-            verticalOffset = verticalOffset > scrollViewer.ScrollableHeight ? scrollViewer.ScrollableHeight : verticalOffset;
+            if (horizontalOffset > scrollViewer.ScrollableWidth)
+            {
+                horizontalOffset = scrollViewer.ScrollableWidth;
+            }
+            else if (horizontalOffset < 0)
+            {
+                horizontalOffset = 0;
+            }
+
+            if (verticalOffset > scrollViewer.ScrollableHeight)
+            {
+                verticalOffset = scrollViewer.ScrollableHeight;
+            }
+            else if (verticalOffset < 0)
+            {
+                verticalOffset = 0;
+            }
 
             // MUST check this and return immediately, otherwise this async task will never complete because ViewChanged event won't get triggered
             if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
-            // MUST check this and return immediately, otherwise this async task will never completes because ViewChanged event won't triggered
+            // MUST check this and return immediately, otherwise this async task will never complete because ViewChanged event won't get triggered
             if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)
             {
                 return;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -203,7 +203,15 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             var tcs = new TaskCompletionSource<VoidResult>();
 
-            void ViewChanged(object _, ScrollViewerViewChangedEventArgs __) => tcs.TrySetResult(result: default);
+            void ViewChanged(object _, ScrollViewerViewChangedEventArgs e)
+            {
+                if (e.IsIntermediate)
+                {
+                    return;
+                }
+
+                tcs.TrySetResult(result: default);
+            }
 
             try
             {

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -56,15 +56,15 @@ namespace Microsoft.Toolkit.Uwp.UI
                 previousXOffset = scrollViewer.HorizontalOffset;
                 previousYOffset = scrollViewer.VerticalOffset;
 
-                var tcs = new TaskCompletionSource<VoidResult>();
+                var tcs = new TaskCompletionSource<object>();
 
-                void ViewChanged(object obj, ScrollViewerViewChangedEventArgs args) => tcs.TrySetResult(result: default);
+                void ViewChanged(object _, ScrollViewerViewChangedEventArgs __) => tcs.TrySetResult(result: default);
 
                 try
                 {
                     scrollViewer.ViewChanged += ViewChanged;
                     listViewBase.ScrollIntoView(listViewBase.Items[index], ScrollIntoViewAlignment.Leading);
-                    await tcs.Task.ConfigureAwait(true);
+                    await tcs.Task;
                 }
                 finally
                 {
@@ -80,7 +80,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             // Scrolling back to previous position
             if (isVirtualizing)
             {
-                await scrollViewer.ChangeViewAsync(previousXOffset, previousYOffset, zoomFactor: null, disableAnimation: true).ConfigureAwait(true);
+                await scrollViewer.ChangeViewAsync(previousXOffset, previousYOffset, zoomFactor: null, disableAnimation: true);
             }
 
             var listViewBaseWidth = listViewBase.ActualWidth;
@@ -172,7 +172,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            await scrollViewer.ChangeViewAsync(finalXPosition, finalYPosition, zoomFactor: null, disableAnimation).ConfigureAwait(true);
+            await scrollViewer.ChangeViewAsync(finalXPosition, finalYPosition, zoomFactor: null, disableAnimation);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>Returns <see cref="Task"/> that completes after scrolling</returns>
         public static async Task SmoothScrollIntoViewWithItemAsync(this ListViewBase listViewBase, object item, ScrollItemPlacement itemPlacement = ScrollItemPlacement.Default, bool disableAnimation = false, bool scrollIfVisibile = true, int additionalHorizontalOffset = 0, int additionalVerticalOffset = 0)
         {
-            await SmoothScrollIntoViewWithIndexAsync(listViewBase, listViewBase.Items.IndexOf(item), itemPlacement, disableAnimation, scrollIfVisibile, additionalHorizontalOffset, additionalVerticalOffset).ConfigureAwait(true);
+            await SmoothScrollIntoViewWithIndexAsync(listViewBase, listViewBase.Items.IndexOf(item), itemPlacement, disableAnimation, scrollIfVisibile, additionalHorizontalOffset, additionalVerticalOffset);
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
-            var tcs = new TaskCompletionSource<VoidResult>();
+            var tcs = new TaskCompletionSource<object>();
 
             void ViewChanged(object _, ScrollViewerViewChangedEventArgs e)
             {
@@ -217,20 +217,12 @@ namespace Microsoft.Toolkit.Uwp.UI
             {
                 scrollViewer.ViewChanged += ViewChanged;
                 scrollViewer.ChangeView(horizontalOffset, verticalOffset, zoomFactor, disableAnimation);
-                await tcs.Task.ConfigureAwait(true);
+                await tcs.Task;
             }
             finally
             {
                 scrollViewer.ViewChanged -= ViewChanged;
             }
-        }
-
-        /// <summary>
-        /// Used as a placeholder TResult to indicate that a <![CDATA[Task<TResult>]]>  has a void TResult
-        /// </summary>
-        /// <see href="https://referencesource.microsoft.com/#System.Core/System/Threading/Tasks/TaskExtensions.cs,6e36a68760fb02e6,references"/>
-        private struct VoidResult
-        {
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
-            // MUST check this an return immediately, otherwise this async task will never completes because ViewChanged event won't triggered
+            // MUST check this and return immediately, otherwise this async task will never completes because ViewChanged event won't triggered
             if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)
             {
                 return;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.SmoothScrollIntoView.cs
@@ -201,6 +201,12 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="disableAnimation">if set to <c>true</c> disable animation.</param>
         private static async Task ChangeViewAsync(this ScrollViewer scrollViewer, double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
         {
+            // MUST check this an return immediately, otherwise this async task will never completes because ViewChanged event won't triggered
+            if (horizontalOffset == scrollViewer.HorizontalOffset && verticalOffset == scrollViewer.VerticalOffset)
+            {
+                return;
+            }
+
             var tcs = new TaskCompletionSource<object>();
 
             void ViewChanged(object _, ScrollViewerViewChangedEventArgs e)


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other --> 

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #4128
<!-- Add the relevant issue number after the "#" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Currently, `SmoothScrollIntoViewWithIndexAsync` is not truly asynchronous but it will return a `Task`.


## What is the new behavior?
SmoothScrollIntoView method should be truly asynchronous. It should wait until the animation completes


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information

~~I have not tested this since I am encountering an issue while building the application locally. Below is the issue I am facing while building (It's **not related to this code change**)~~
![image](https://user-images.githubusercontent.com/24755596/126913322-878ffeaf-b2b7-4987-943e-1038a0bd60a2.png)

~~I will try to solve this issue. In meantime, **can anyone test this PR if possible?** sorry for this inconvenience~~