### PR TITLE
Fix warnings in HighPerformance/Mvvm unit tests

### DIFF
--- a/UnitTests/UnitTests.HighPerformance.Shared/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Enumerables/Test_ReadOnlyRefEnumerable{T}.cs
@@ -5,6 +5,7 @@
 #if !WINDOWS_UWP
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.Toolkit.HighPerformance.Enumerables;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace UnitTests.HighPerformance.Enumerables
 {
     [TestClass]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649", Justification = "Test class for generic type")]
     public class Test_ReadOnlyRefEnumerable
     {
         [TestCategory("ReadOnlyRefEnumerable")]

--- a/UnitTests/UnitTests.HighPerformance.Shared/Enumerables/Test_RefEnumerable{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Enumerables/Test_RefEnumerable{T}.cs
@@ -5,6 +5,7 @@
 #if !WINDOWS_UWP
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.Toolkit.HighPerformance.Enumerables;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace UnitTests.HighPerformance.Enumerables
 {
     [TestClass]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649", Justification = "Test class for generic type")]
     public class Test_RefEnumerable
     {
         [TestCategory("RefEnumerable")]

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ICommandAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ICommandAttribute.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CS0618
-
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -11,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_ICommandAttribute
     {

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_INotifyPropertyChangedAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_INotifyPropertyChangedAttribute.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_INotifyPropertyChangedAttribute
     {

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_IRecipientGenerator.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_IRecipientGenerator.cs
@@ -5,11 +5,13 @@
 #pragma warning disable CS0618
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Toolkit.Mvvm.Messaging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_IRecipientGenerator
     {

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservableObjectAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservableObjectAttribute.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_ObservableObjectAttribute
     {

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,6 +15,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_ObservablePropertyAttribute
     {
@@ -105,9 +107,10 @@ namespace UnitTests.Mvvm
             Assert.AreEqual(testAttribute.D, 6.28);
             CollectionAssert.AreEqual(testAttribute.Names, new[] { "Bob", "Ross" });
 
-            object[] nestedArray = (object[])testAttribute.NestedArray;
+            object[]? nestedArray = (object[]?)testAttribute.NestedArray;
 
-            Assert.AreEqual(nestedArray.Length, 3);
+            Assert.IsNotNull(nestedArray);
+            Assert.AreEqual(nestedArray!.Length, 3);
             Assert.AreEqual(nestedArray[0], 1);
             Assert.AreEqual(nestedArray[1], "Hello");
             Assert.IsTrue(nestedArray[2] is int[]);
@@ -181,7 +184,7 @@ namespace UnitTests.Mvvm
 
             public string[] Names { get; }
 
-            public object NestedArray { get; set; }
+            public object? NestedArray { get; set; }
 
             public Animal Animal { get; set; }
         }

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservableRecipientAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservableRecipientAttribute.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
@@ -13,6 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_ObservableRecipientAttribute
     {

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Toolkit.Mvvm.Messaging;
@@ -10,6 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm
 {
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601", Justification = "Type only used for testing")]
     [TestClass]
     public partial class Test_Messenger
     {


### PR DESCRIPTION
## Fixes https://github.com/CommunityToolkit/WindowsCommunityToolkit/pull/4102#issuecomment-888964962
<!-- Add the relevant issue number after the "#" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Maintenance
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some HighPerformance/Mvvm unit tests produce warnings when the projects are built.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
No more warnings 🙌

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes