### PR TITLE
Added a parameter for configuration(Debug/Release) on the cake build script

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -16,6 +16,7 @@ using System.Text.RegularExpressions;
 //////////////////////////////////////////////////////////////////////
 
 var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Release");
 
 //////////////////////////////////////////////////////////////////////
 // VERSIONS
@@ -35,7 +36,7 @@ var toolsDir = buildDir + "/tools";
 var binDir = baseDir + "/bin";
 var nupkgDir = binDir + "/nupkg";
 
-var taefBinDir = baseDir + "/UITests/UITests.Tests.TAEF/bin/Release/netcoreapp3.1/win10-x86";
+var taefBinDir = baseDir + $"/UITests/UITests.Tests.TAEF/bin/{configuration}/netcoreapp3.1/win10-x86";
 
 var styler = toolsDir + "/XamlStyler.Console/tools/xstyler.exe";
 var stylerFile = baseDir + "/settings.xamlstyler";
@@ -151,7 +152,7 @@ Task("BuildProjects")
     {
         MaxCpuCount = 0
     }
-    .SetConfiguration("Release")
+    .SetConfiguration(configuration)
     .WithTarget("Restore");
 
     MSBuild(Solution, buildSettings);
@@ -163,7 +164,7 @@ Task("BuildProjects")
     {
         MaxCpuCount = 0
     }
-    .SetConfiguration("Release")
+    .SetConfiguration(configuration)
     .WithTarget("Build")
     .WithProperty("GenerateLibraryLayout", "true");
 
@@ -215,7 +216,7 @@ Task("Package")
     {
         MaxCpuCount = 0
     }
-    .SetConfiguration("Release")
+    .SetConfiguration(configuration)
     .WithTarget("Pack")
     .WithProperty("GenerateLibraryLayout", "true")
     .WithProperty("PackageOutputPath", nupkgDir);
@@ -253,13 +254,13 @@ Task("Test")
         ArgumentCustomization = arg => arg.Append("/logger:trx;LogFileName=VsTestResultsUwp.trx /framework:FrameworkUap10"),
     };
 
-    VSTest(baseDir + "/**/Release/**/UnitTests.*.appxrecipe", testSettings);
+    VSTest(baseDir + $"/**/{configuration}/**/UnitTests.*.appxrecipe", testSettings);
 }).DoesForEach(GetFiles(baseDir + "/**/UnitTests.*NetCore.csproj"), (file) =>
 {
     Information("\nRunning NetCore Unit Tests");
     var testSettings = new DotNetCoreTestSettings
     {
-        Configuration = "Release",
+        Configuration = configuration,
         NoBuild = true,
         Loggers = new[] { "trx;LogFilePrefix=VsTestResults" },
         Verbosity = DotNetCoreVerbosity.Normal,
@@ -306,7 +307,7 @@ Task("MSTestUITest")
 
     var testSettings = new DotNetCoreTestSettings
     {
-        Configuration = "Release",
+        Configuration = configuration,
         NoBuild = true,
         Loggers = new[] { "trx;LogFilePrefix=VsTestResults" },
         Verbosity = DotNetCoreVerbosity.Normal


### PR DESCRIPTION
## Fixes #4144

This adds a parameter to the build.cake file to be able to easily build everything in debug mode.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Can only run the build script in Release.

## What is the new behavior?
Builds in Release mode by default, but you can run "build.ps1 -configuration debug" to build everything in debug.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes