### PR TITLE
Updated Windows SDK locator script to make it more resilient to x86 vs x64 environments.

### DIFF
--- a/build/Find-WindowsSDKVersions.ps1
+++ b/build/Find-WindowsSDKVersions.ps1
@@ -82,6 +82,16 @@ function Test-RegistryPathAndValue {
     catch {
     }
 
+    try {
+        $path = $path -replace "HKLM:\\SOFTWARE\\", "HKLM:\\SOFTWARE\\WOW6432Node\\"
+        if (Test-Path $path) {
+            Get-ItemProperty -Path $path | Select-Object -ExpandProperty $value -ErrorAction Stop | Out-Null
+            return $true
+        }
+    }
+    catch {
+    }
+
     return $false
 }
 
@@ -100,6 +110,11 @@ function Test-InstallWindowsSdk([string] $WindowsSDKVersion) {
         if (Test-RegistryPathAndValue -Path $WindowsSDKInstalledRegPath -Value "$WindowsSDKOptions") {
             # It appears we have what we need. Double check the disk
             $sdkRoot = Get-ItemProperty -Path $WindowsSDKRegPath | Select-Object -ExpandProperty $WindowsSDKRegRootKey
+            if (!$sdkRoot) {
+                $WindowsSDKRegPath = $WindowsSDKRegPath -replace "HKLM:\\SOFTWARE\\", "HKLM:\\SOFTWARE\\WOW6432Node\\"
+                $sdkRoot = Get-ItemProperty -Path $WindowsSDKRegPath | Select-Object -ExpandProperty $WindowsSDKRegRootKey
+            }
+            
             if ($sdkRoot) {
                 if (Test-Path $sdkRoot) {
                     $refPath = Join-Path $sdkRoot "References\$WindowsSDKVersion"


### PR DESCRIPTION
This fixes a bug in the Windows SDK locator script to make it check for both x64 and x86 registry keys. The ADO build server, as well as some of our machines, are reproducing this odd behavior, and this PR addresses that bug.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
- Build or CI related changes

## What is the current behavior?
SDK locator script crashing depending if the registry keys that it looks for exists in x64 or x86 land.

## What is the new behavior?
SDK locator script checks for both x64 and x86 registry keys, making it more reliable.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes