### PR TITLE
fix: Prevent focus reset for DataGridTemplateColumn

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -5729,6 +5729,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 bool focusLeftDataGrid = true;
                 bool dataGridWillReceiveRoutedEvent = true;
+                DataGridColumn editingColumn = null;
 
                 // Walk up the visual tree of the newly focused element
                 // to determine if focus is still within DataGrid.
@@ -5768,7 +5769,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     focusedDependencyObject = parent;
                 }
 
-                if (focusLeftDataGrid)
+                if (this.EditingRow != null && this.EditingColumnIndex != -1)
+                {
+                    editingColumn = this.ColumnsItemsInternal[this.EditingColumnIndex];
+
+                    if (focusLeftDataGrid && editingColumn is DataGridTemplateColumn)
+                    {
+                        dataGridWillReceiveRoutedEvent = false;
+                    }
+                }
+
+                if (focusLeftDataGrid && !(editingColumn is DataGridTemplateColumn))
                 {
                     this.ContainsFocus = false;
                     if (this.EditingRow != null)


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other --> 

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/2493
<!-- Add the relevant issue number after the "#" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
This prevents DataGrid from assuming focus should be reset back to itself when a control inside DataGridTemplateColumn gains focus. This is my first WCT PR, so please go easy on me 😆 
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->
Bugfix 
<!-- - -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Trying to open a control like CalendarDatePicker from within a DataGridTemplateColumn doesn't work, as there is specific behavior to detect when DataGrid loses focus and return it. This doesn't make much sense for controls which require focus to function properly.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
When the DataGrid loses focus, we now specifically detect if the editing column is a DataGridTemplateColumn and alter the behavior to accommodate this.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
I'm unsure if this is the *best* way to do this, but it makes the most sense given how DataGrid already has the capability to detect the editing element and column type.

Related: https://github.com/unoplatform/uno/issues/6543