### PR TITLE
Forced AnyCPU on builds.

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -150,7 +150,8 @@ Task("BuildProjects")
     Information("\nBuilding Solution");
     var buildSettings = new MSBuildSettings
     {
-        MaxCpuCount = 0
+        MaxCpuCount = 0,
+        PlatformTarget = PlatformTarget.MSIL
     }
     .SetConfiguration(configuration)
     .WithTarget("Restore");
@@ -162,7 +163,8 @@ Task("BuildProjects")
     // Build once with normal dependency ordering
     buildSettings = new MSBuildSettings
     {
-        MaxCpuCount = 0
+        MaxCpuCount = 0,
+        PlatformTarget = PlatformTarget.MSIL
     }
     .SetConfiguration(configuration)
     .WithTarget("Build")
@@ -214,7 +216,8 @@ Task("Package")
     // Invoke the pack target in the end
     var buildSettings = new MSBuildSettings
     {
-        MaxCpuCount = 0
+        MaxCpuCount = 0,
+        PlatformTarget = PlatformTarget.MSIL
     }
     .SetConfiguration(configuration)
     .WithTarget("Pack")
@@ -264,7 +267,7 @@ Task("Test")
         NoBuild = true,
         Loggers = new[] { "trx;LogFilePrefix=VsTestResults" },
         Verbosity = DotNetCoreVerbosity.Normal,
-        ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings"),
+        ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings /p:platform=\"AnyCpu\""),
     };
     DotNetCoreTest(file.FullPath, testSettings);
 }).DeferOnError();

--- a/build/build.cake
+++ b/build/build.cake
@@ -267,7 +267,7 @@ Task("Test")
         NoBuild = true,
         Loggers = new[] { "trx;LogFilePrefix=VsTestResults" },
         Verbosity = DotNetCoreVerbosity.Normal,
-        ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings /p:platform=\"AnyCpu\""),
+        ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings /p:Platform=AnyCPU"),
     };
     DotNetCoreTest(file.FullPath, testSettings);
 }).DeferOnError();


### PR DESCRIPTION
## Fixes #4149

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Build fails if the Platform env variable is set to anything other than AnyCPU.

## What is the new behavior?
Forces AnyCPU builds on MSBuild calls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
