### PR TITLE
Fixes AlternatingRowForeground not being applied

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridRow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridRow.cs
@@ -1122,40 +1122,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 DiagnosticsDebug.Assert(this.Index != -1, "Expected Index other than -1.");
 
-                PropertyMetadata metadataInfo = DataGridRow.ForegroundProperty.GetMetadata(typeof(DataGridRow));
-                Brush defaultForeground = metadataInfo == null ? null : metadataInfo.DefaultValue as Brush;
-                Brush newForeground = null;
+                Brush newForeground = this.Index % 2 == 0 || this.OwningGrid.AlternatingRowForeground == null
+                    ? this.OwningGrid.RowForeground
+                    : this.OwningGrid.AlternatingRowForeground;
 
-                if (this.Foreground.Equals(defaultForeground))
-                {
-                    if (this.Index % 2 == 0 || this.OwningGrid.AlternatingRowForeground == null)
-                    {
-                        // Use OwningGrid.RowForeground if the index is even or if the OwningGrid.AlternatingRowForeground is null
-                        if (this.OwningGrid.RowForeground != null)
-                        {
-                            newForeground = this.OwningGrid.RowForeground;
-                        }
-                    }
-                    else
-                    {
-                        // Alternate row
-                        if (this.OwningGrid.AlternatingRowForeground != null)
-                        {
-                            newForeground = this.OwningGrid.AlternatingRowForeground;
-                        }
-                    }
-
-                    if (newForeground == null)
-                    {
-                        newForeground = this.Foreground;
-                    }
-                }
-                else
-                {
-                    newForeground = this.Foreground;
-                }
-
-                this.ComputedForeground = newForeground;
+                this.ComputedForeground = newForeground ?? this.Foreground;
             }
             else
             {


### PR DESCRIPTION
Fixes AlternatingRowForeground not being applied when in Light theme.
Dark theme is OK.

## Fixes #4140

Fixes AlternatingRowForeground not being applied when in Light theme.


<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
The AlternatingRowForeground is not applied when in Light theme because the default value for the dependency property DataGridRow.Foreground is #FFFFFFFF but the foreground brush itself under Light Theme is not. That causes the LOC # 1129 (see below) to always evaluate to false under Light Theme, which in turn leads to the AlternatingRowForeground brush to be ignored every time.
[1129]       if (this.Foreground.Equals(defaultForeground))


## What is the new behavior?
This commit removes LOC # 1129 for causing the undesirable behavior. It also simplifies the resulting code.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


## Other information
Tested in Windows 21H1 only.Tested in Windows 21H1 only.

Edit no. 1: Fix the number of the issue that this PR aims to solve.