### PR TITLE
Add Value Coercion to ConstrainedBox

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
@@ -93,11 +93,71 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty AspectRatioProperty =
             DependencyProperty.Register(nameof(AspectRatio), typeof(AspectRatio), typeof(ConstrainedBox), new PropertyMetadata(null, ConstraintPropertyChanged));
 
+        private bool _propertyUpdating;
+
         private static void ConstraintPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (d is ConstrainedBox panel)
+            if (d is ConstrainedBox panel && !panel._propertyUpdating)
             {
+                panel._propertyUpdating = true;
+
+                panel.CoerceValues();
+
                 panel.InvalidateMeasure();
+
+                panel._propertyUpdating = false;
+            }
+        }
+
+        private void CoerceValues()
+        {
+            // Check if scale properties are in range
+            if (!double.IsNaN(ScaleX))
+            {
+                if (ScaleX < 0)
+                {
+                    ScaleX = 0;
+                }
+                else if (ScaleX > 1.0)
+                {
+                    ScaleX = 1.0;
+                }
+            }
+            else
+            {
+                ScaleX = 1.0;
+            }
+
+            if (!double.IsNaN(ScaleY))
+            {
+                if (ScaleY < 0)
+                {
+                    ScaleY = 0;
+                }
+                else if (ScaleY > 1.0)
+                {
+                    ScaleY = 1.0;
+                }
+            }
+            else
+            {
+                ScaleY = 1.0;
+            }
+
+            // Clear invalid values less than 0 for other properties
+            if (ReadLocalValue(MultipleXProperty) is int value && value <= 0)
+            {
+                ClearValue(MultipleXProperty);
+            }
+
+            if (ReadLocalValue(MultipleYProperty) is int value2 && value2 <= 0)
+            {
+                ClearValue(MultipleYProperty);
+            }
+
+            if (ReadLocalValue(AspectRatioProperty) is AspectRatio ratio && ratio <= 0)
+            {
+                ClearValue(AspectRatioProperty);
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="MultipleX"/> property.
         /// </summary>
         public static readonly DependencyProperty MultipleXProperty =
-            DependencyProperty.Register(nameof(MultipleX), typeof(int), typeof(ConstrainedBox), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(MultipleX), typeof(int), typeof(ConstrainedBox), new PropertyMetadata(null, ConstraintPropertyChanged));
 
         /// <summary>
         /// Gets or sets the integer multiple that the height of the panel should be floored to. Default is null (no snap).
@@ -76,7 +76,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="MultipleY"/> property.
         /// </summary>
         public static readonly DependencyProperty MultipleYProperty =
-            DependencyProperty.Register(nameof(MultipleY), typeof(int), typeof(ConstrainedBox), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(MultipleY), typeof(int), typeof(ConstrainedBox), new PropertyMetadata(null, ConstraintPropertyChanged));
 
         /// <summary>
         /// Gets or sets aspect Ratio to use for the contents of the Panel (after scaling).

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
@@ -45,6 +45,7 @@ namespace UnitTests.UWP.UI.Controls
     <Grid x:Name=""ParentGrid""
           Width=""200"" Height=""200"">
       <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"" MaxHeight=""100""
+                               UseLayoutRounding=""False""
                                HorizontalAlignment=""{horizontalAlignment}""
                                VerticalAlignment=""{verticalAlignment}"">
         <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UnitTests.UWP.UI.Controls
+{
+    /// <summary>
+    /// These tests check whether the inner alignment of the box within it's parent works as expected.
+    /// </summary>
+    public partial class Test_ConstrainedBox : VisualUITestBase
+    {
+        // For this test we're testing within the confines of a 200x200 box to position a contrained
+        // 50x100 element in all the different alignment combinations.
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        [DataRow("Left", 0, "Center", 50, DisplayName = "LeftCenter")]
+        [DataRow("Left", 0, "Top", 0, DisplayName = "LeftTop")]
+        [DataRow("Center", 75, "Top", 0, DisplayName = "CenterTop")]
+        [DataRow("Right", 150, "Top", 0, DisplayName = "RightTop")]
+        [DataRow("Right", 150, "Center", 50, DisplayName = "RightCenter")]
+        [DataRow("Right", 150, "Bottom", 100, DisplayName = "RightBottom")]
+        [DataRow("Center", 75, "Bottom", 100, DisplayName = "CenterBottom")]
+        [DataRow("Left", 0, "Bottom", 100, DisplayName = "LeftBottom")]
+        [DataRow("Center", 75, "Center", 50, DisplayName = "CenterCenter")]
+        public async Task Test_ConstrainedBox_Alignment_Aspect(string horizontalAlignment, int expectedLeft, string verticalAlignment, int expectedTop)
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@$"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <Grid x:Name=""ParentGrid""
+          Width=""200"" Height=""200"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"" MaxHeight=""100""
+                               HorizontalAlignment=""{horizontalAlignment}""
+                               VerticalAlignment=""{verticalAlignment}"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </Grid>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var grid = treeRoot.FindChild("ParentGrid") as Grid;
+
+                Assert.IsNotNull(grid, "Could not find the ParentGrid in tree.");
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(50, child.ActualWidth, 0.01, "Actual width does not meet expected value of 50");
+                Assert.AreEqual(100, child.ActualHeight, 0.01, "Actual height does not meet expected value of 100");
+
+                // Check inner Positioning, we do this from the Grid as the ConstainedBox also modifies its own size
+                // and is hugging the child.
+                var position = grid.CoordinatesTo(child);
+
+                Assert.AreEqual(expectedLeft, position.X, 0.01, "X position does not meet expected value of 0");
+                Assert.AreEqual(expectedTop, position.Y, 0.01, "Y position does not meet expected value of 50");
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Coerce.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Coerce.cs
@@ -16,6 +16,9 @@ using Windows.UI.Xaml.Markup;
 
 namespace UnitTests.UWP.UI.Controls
 {
+    /// <summary>
+    /// These tests check for the various values which can be coerced and changed if out of bounds for each property.
+    /// </summary>
     public partial class Test_ConstrainedBox : VisualUITestBase
     {
         [TestCategory("ConstrainedBox")]

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Coerce.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Coerce.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UnitTests.UWP.UI.Controls
+{
+    public partial class Test_ConstrainedBox : VisualUITestBase
+    {
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Coerce_Scale()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" ScaleX=""0.5"" ScaleY=""0.5""/>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Check Size
+                Assert.AreEqual(0.5, panel.ScaleX, 0.01, "ScaleX does not meet expected initial value of 0.5");
+                Assert.AreEqual(0.5, panel.ScaleY, 0.01, "ScaleY does not meet expected initial value of 0.5");
+
+                // Change values now to be invalid
+                panel.ScaleX = double.NaN;
+                panel.ScaleY = double.NaN;
+
+                Assert.AreEqual(1.0, panel.ScaleX, 0.01, "ScaleX does not meet expected value of 1.0 after change.");
+                Assert.AreEqual(1.0, panel.ScaleY, 0.01, "ScaleY does not meet expected value of 1.0 after change.");
+
+                // Change values now to be invalid
+                panel.ScaleX = double.NegativeInfinity;
+                panel.ScaleY = double.NegativeInfinity;
+
+                Assert.AreEqual(0.0, panel.ScaleX, 0.01, "ScaleX does not meet expected value of 0.0 after change.");
+                Assert.AreEqual(0.0, panel.ScaleY, 0.01, "ScaleY does not meet expected value of 0.0 after change.");
+
+                // Change values now to be invalid
+                panel.ScaleX = double.PositiveInfinity;
+                panel.ScaleY = double.PositiveInfinity;
+
+                Assert.AreEqual(1.0, panel.ScaleX, 0.01, "ScaleX does not meet expected value of 1.0 after change.");
+                Assert.AreEqual(1.0, panel.ScaleY, 0.01, "ScaleY does not meet expected value of 1.0 after change.");
+            });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Coerce_Multiple()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" MultipleX=""32"" MultipleY=""32""/>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Check Size
+                Assert.AreEqual(32, panel.MultipleX, "MultipleX does not meet expected value of 32");
+                Assert.AreEqual(32, panel.MultipleY, "MultipleY does not meet expected value of 32");
+
+                // Change values now to be invalid
+                panel.MultipleX = 0;
+                panel.MultipleY = int.MinValue;
+
+                Assert.AreEqual(DependencyProperty.UnsetValue, panel.ReadLocalValue(ConstrainedBox.MultipleXProperty), "MultipleX does not meet expected value of UnsetValue after change.");
+                Assert.AreEqual(DependencyProperty.UnsetValue, panel.ReadLocalValue(ConstrainedBox.MultipleYProperty), "MultipleY does not meet expected value of UnsetValue after change.");
+            });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Coerce_AspectRatio()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1.25:3.5""/>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Check Size
+                Assert.AreEqual(1.25 / 3.5, panel.AspectRatio, 0.01, "ApectRatio does not meet expected value of 1.25/3.5");
+
+                // Change values now to be invalid
+                panel.AspectRatio = -1;
+
+                Assert.AreEqual(DependencyProperty.UnsetValue, panel.ReadLocalValue(ConstrainedBox.AspectRatioProperty), "AspectRatio does not meet expected value of UnsetValue after change.");
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Combined.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Combined.cs
@@ -17,6 +17,9 @@ using Windows.UI.Xaml.Markup;
 
 namespace UnitTests.UWP.UI.Controls
 {
+    /// <summary>
+    /// These tests check multiple constraints are applied together in the correct order.
+    /// </summary>
     public partial class Test_ConstrainedBox : VisualUITestBase
     {
         [TestCategory("ConstrainedBox")]

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Constrict.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Constrict.cs
@@ -29,10 +29,6 @@ namespace UnitTests.UWP.UI.Controls
         {
             await App.DispatcherQueue.EnqueueAsync(async () =>
             {
-                // Even though we constrain the size of the ScrollViewer, it initially reports infinite measure
-                // which is what we want to test. We constrain the dimension so that we have a specific value
-                // that we can measure against. If we instead restrained the inner Border, it'd just set
-                // it's side within the constrained space of the parent layout...
                 var treeRoot = XamlReader.Load(@"<Page
     xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
     xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Constrict.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Constrict.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UnitTests.UWP.UI.Controls
+{
+    /// <summary>
+    /// These tests check for cases where we want to constrain the size of the ConstrainedBox with other
+    /// properties like MaxWidth and MaxHeight. The ConstrainedBox is greedy about using all the available
+    /// space, so Min properties don't really play the same factor? At least hard to create a practical test.
+    /// </summary>
+    public partial class Test_ConstrainedBox : VisualUITestBase
+    {
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Constrain_AspectMaxHeight()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                // Even though we constrain the size of the ScrollViewer, it initially reports infinite measure
+                // which is what we want to test. We constrain the dimension so that we have a specific value
+                // that we can measure against. If we instead restrained the inner Border, it'd just set
+                // it's side within the constrained space of the parent layout...
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <Grid HorizontalAlignment=""Center"" VerticalAlignment=""Center"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""2:1"" MaxHeight=""100"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </Grid>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(200, child.ActualWidth, 0.01, "Actual width does not meet expected value of 200");
+                Assert.AreEqual(100, child.ActualHeight, 0.01, "Actual height does not meet expected value of 100");
+            });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Constrain_AspectMaxWidth()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <Grid HorizontalAlignment=""Center"" VerticalAlignment=""Center"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""2:1"" MaxWidth=""100"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </Grid>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(100, child.ActualWidth, 0.01, "Actual width does not meet expected value of 100");
+                Assert.AreEqual(50, child.ActualHeight, 0.01, "Actual height does not meet expected value of 50");
+            });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_Constrain_AspectBothMaxWidthHeight()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <Grid HorizontalAlignment=""Center"" VerticalAlignment=""Center"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"" MaxWidth=""200"" MaxHeight=""200"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </Grid>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(100, child.ActualWidth, 0.01, "Actual width does not meet expected value of 100");
+                Assert.AreEqual(200, child.ActualHeight, 0.01, "Actual height does not meet expected value of 200");
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
@@ -106,5 +106,52 @@ namespace UnitTests.UWP.UI.Controls
                 Assert.AreEqual(200, child.ActualHeight, 0.01, "Actual height does not meet expected value of 200");
             });
         }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_AllInfinite_AspectBothFallback()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <ScrollViewer x:Name=""ScrollArea""
+                  HorizontalScrollMode=""Enabled"" HorizontalScrollBarVisibility=""Visible""
+                  VerticalScrollMode=""Enabled"" VerticalScrollBarVisibility=""Visible"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </ScrollViewer>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var scroll = treeRoot.FindChild("ScrollArea") as ScrollViewer;
+
+                Assert.IsNotNull(scroll, "Could not find ScrollViewer in tree.");
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                var width = scroll.ActualHeight / 2;
+
+                // Check Size
+                Assert.AreEqual(width, child.ActualWidth, 0.01, "Actual width does not meet expected value of " + width);
+                Assert.AreEqual(scroll.ActualHeight, child.ActualHeight, 0.01, "Actual height does not meet expected value of " + scroll.ActualHeight);
+            });
+        }
     }
 }

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UnitTests.UWP.UI.Controls
+{
+    /// <summary>
+    /// These tests check for cases where one of the bounds provided by the parent panel is infinite.
+    /// </summary>
+    public partial class Test_ConstrainedBox : VisualUITestBase
+    {
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_AllInfinite_AspectWidthFallback()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                // Even though we constrain the size of the ScrollViewer, it initially reports infinite measure
+                // which is what we want to test. We constrain the dimension so that we have a specific value
+                // that we can measure against. If we instead restrained the inner Border, it'd just set
+                // it's side within the constrained space of the parent layout...
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <ScrollViewer HorizontalScrollMode=""Enabled"" HorizontalScrollBarVisibility=""Visible""
+                  VerticalScrollMode=""Enabled"" VerticalScrollBarVisibility=""Visible""
+                  Width=""200"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""2:1"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </ScrollViewer>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(200, child.ActualWidth, 0.01, "Actual width does not meet expected value of 200");
+                Assert.AreEqual(100, child.ActualHeight, 0.01, "Actual height does not meet expected value of 100");
+            });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public async Task Test_ConstrainedBox_AllInfinite_AspectHeightFallback()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var treeRoot = XamlReader.Load(@"<Page
+    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls"">
+    <ScrollViewer HorizontalScrollMode=""Enabled"" HorizontalScrollBarVisibility=""Visible""
+                  VerticalScrollMode=""Enabled"" VerticalScrollBarVisibility=""Visible""
+                  Height=""200"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"">
+        <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
+      </controls:ConstrainedBox>
+    </ScrollViewer>
+</Page>") as FrameworkElement;
+
+                Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
+
+                // Initialize Visual Tree
+                await SetTestContentAsync(treeRoot);
+
+                var panel = treeRoot.FindChild("ConstrainedBox") as ConstrainedBox;
+
+                Assert.IsNotNull(panel, "Could not find ConstrainedBox in tree.");
+
+                // Force Layout calculations
+                panel.UpdateLayout();
+
+                var child = panel.Content as Border;
+
+                Assert.IsNotNull(child, "Could not find inner Border");
+
+                // Check Size
+                Assert.AreEqual(100, child.ActualWidth, 0.01, "Actual width does not meet expected value of 100");
+                Assert.AreEqual(200, child.ActualHeight, 0.01, "Actual height does not meet expected value of 200");
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -229,6 +229,7 @@
     <Compile Include="UI\Collection\Test_IncrementalLoadingCollection.cs" />
     <Compile Include="UI\Controls\Test_Carousel.cs" />
     <Compile Include="UI\Controls\Test_BladeView.cs" />
+    <Compile Include="UI\Controls\Test_ConstrainedBox.Constrict.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Infinity.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.AspectRatio.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Coerce.cs" />

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -229,6 +229,7 @@
     <Compile Include="UI\Collection\Test_IncrementalLoadingCollection.cs" />
     <Compile Include="UI\Controls\Test_Carousel.cs" />
     <Compile Include="UI\Controls\Test_BladeView.cs" />
+    <Compile Include="UI\Controls\Test_ConstrainedBox.Infinity.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.AspectRatio.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Coerce.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Multiple.cs" />

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -230,6 +230,7 @@
     <Compile Include="UI\Controls\Test_Carousel.cs" />
     <Compile Include="UI\Controls\Test_BladeView.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.AspectRatio.cs" />
+    <Compile Include="UI\Controls\Test_ConstrainedBox.Coerce.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Multiple.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Combined.cs" />
     <Compile Include="UI\Controls\Test_ImageEx.cs" />

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -229,6 +229,7 @@
     <Compile Include="UI\Collection\Test_IncrementalLoadingCollection.cs" />
     <Compile Include="UI\Controls\Test_Carousel.cs" />
     <Compile Include="UI\Controls\Test_BladeView.cs" />
+    <Compile Include="UI\Controls\Test_ConstrainedBox.Alignment.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Constrict.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Infinity.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.AspectRatio.cs" />


### PR DESCRIPTION
## Fixes #4166 too
Adds Value Coercion to the properties to ensure they're within a valid range.

Also fixes the issue with MultipleX/Y not triggering layout updates.

Debating whether to add more tests to this PR or not still... 🤔

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
Can specify any values for properties.

## What is the new behavior?
Will reset/bound properties to expected values if out-of-range.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
