### PR TITLE
Clear ReferenceNode ParamNames before serializing each expression string to avoid collisions

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/CompositionExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/CompositionExtensions.cs
@@ -176,6 +176,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         /// <param name="easing">The easing function to use when interpolating between frames.</param>
         public static void InsertExpressionKeyFrame(this KeyFrameAnimation keyframeAnimation, float normalizedProgressKey, ExpressionNode expressionNode, CompositionEasingFunction easing = null)
         {
+            expressionNode.ClearReferenceInfo();
+
             keyframeAnimation.InsertExpressionKeyFrame(normalizedProgressKey, expressionNode.ToExpressionString(), easing);
 
             expressionNode.SetAllParameters(keyframeAnimation);
@@ -252,6 +254,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
             // Only create a new animation if this node hasn't already generated one before, so we don't have to re-parse the expression string.
             if (expressionNode.ExpressionAnimation == null)
             {
+                expressionNode.ClearReferenceInfo();
                 expressionNode.ExpressionAnimation = compositor.CreateExpressionAnimation(expressionNode.ToExpressionString());
             }
 

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ExpressionNode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ExpressionNode.cs
@@ -261,6 +261,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         /// <summary>
+        /// Clears the reference information.
+        /// </summary>
+        /// <exception cref="System.Exception">Reference and paramName can't both be null</exception>
+        internal void ClearReferenceInfo()
+        {
+            _objRefList = null;
+            ParamName = null;
+            foreach (var child in Children)
+            {
+                child.ClearReferenceInfo();
+            }
+        }
+
+        /// <summary>
         /// Ensures the reference information.
         /// </summary>
         /// <exception cref="System.Exception">Reference and paramName can't both be null</exception>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

 - Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

This is a fix that prevents name collisions when nodes/subtrees are reused to build more than one expression string. It is not completely clear to me if reusing nodes/subtrees to build multiple expression strings is a explicitly supported scenario, but the docs don't warn against it and it is imo desirable to:
  - Avoid having to rebuild the same tree of nodes over and over when animating collections of elements
  - Avoid having to rebuild the same tree of nodes for animating properties that share an "animation subtree"
  - Stay in the realm of ReferenceNodes in our animation classes, rather than pass them the whole InteractionTracker/PropertySet (giving them "write access") just so they can call GetReference() as many times as they need.
 
As far as I can tell, the underlying issue has already existed independently of whether we use the "InteractionTracker_1", guids or alphabetical identifiers, but it is now easier to hit since my previous PR #4112 makes the ids sequential.

## What is the current behavior?

Currently, if you try to reuse a ReferenceNode across many animations, we only set the ParamName of each node once and we reuse the old name on future animations. Since ParamNames are only guaranteed to be unique for each call to EnsureReferenceInfo, this can result in two nodes having the same ParamName, e.g. 

```csharp
            //Create tracker and properties
            var visual = ElementCompositionPreview.GetElementVisual(this);
            var compositor = visual.Compositor;

            var tracker = InteractionTracker.Create(compositor);

            var properties = compositor.CreatePropertySet();
            const string SomeProperty = nameof(SomeProperty);
            properties.InsertBoolean(SomeProperty, false);

            var propertiesReference = properties.GetReference();
            var trackerReference = tracker.GetReference();

            //Create an expression tree that contains one of the references - it will be named A
            var opacityAnimation = ExpressionFunctions.Conditional(propertiesReference.GetBooleanProperty(SomeProperty), 1, 0);
            visual.StartAnimation("Opacity", opacityAnimation);
            //Resolves to ((A.SomeProperty) ? 1 : (0))

            //Create an expression tree that contains both references - one is already named A, the other will be named A
            var positionAnimation = ExpressionFunctions.Conditional(propertiesReference.GetBooleanProperty(SomeProperty), trackerReference.Position.X, 0);
            visual.StartAnimation("Offset.X", positionAnimation);
            // Resolves to ((A.SomeProperty) ? (A.Position.X) : (0))
```

throws 

```
System.ArgumentException
  HResult=0x80070057
  Message=The parameter is incorrect.

The specified property was not found or cannot be referenced in an expression.
Context: SomeProperty
Expression: ((A.SomeProperty) ? (A.Position.X) : (0))
...
```

This means that in practice it is dangerous to reuse references nodes as collisions might happen in a way that is hard to predict, depending on the tree of each animation and the order in which they start. E.g. in the previous example, the code runs fine if we swap the order of the StartAnimation calls.

## What is the new behavior?

ClearReferenceInfo is always called before ToExpressionString, wiping the ParamName and _objRefList in each node in the tree. This has a small cost since it involves traversing the tree, but guarantees that we don't reuse stale data from previous calls.

An alternative solution would be to clear the data after/at the end of each ToExpressionString call, to guarantee that the nodes are always in a clean state.

<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->