### PR TITLE
Fix for ConstrainedBox test in high DPI

### DIFF
--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Infinity.cs
@@ -120,7 +120,7 @@ namespace UnitTests.UWP.UI.Controls
     <ScrollViewer x:Name=""ScrollArea""
                   HorizontalScrollMode=""Enabled"" HorizontalScrollBarVisibility=""Visible""
                   VerticalScrollMode=""Enabled"" VerticalScrollBarVisibility=""Visible"">
-      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"">
+      <controls:ConstrainedBox x:Name=""ConstrainedBox"" AspectRatio=""1:2"" UseLayoutRounding=""False"">
         <Border HorizontalAlignment=""Stretch"" VerticalAlignment=""Stretch"" Background=""Red""/>
       </controls:ConstrainedBox>
     </ScrollViewer>


### PR DESCRIPTION
## Fixes #4190

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Test_ConstrainedBox_AllInfinite_AspectBothFallback  fails on 150% DPI

## What is the new behavior?
Test_ConstrainedBox_AllInfinite_AspectBothFallback works on any DPI.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->