### PR TITLE
ListDetailsView now uses the Two-Pane View

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Metadata.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Metadata.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-
 using Microsoft.Toolkit.Uwp.UI.Controls.Design.Properties;
-
 using Microsoft.VisualStudio.DesignTools.Extensibility;
 using Microsoft.VisualStudio.DesignTools.Extensibility.Metadata;
+using System.ComponentModel;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
 {
@@ -25,6 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
                         new EditorBrowsableAttribute(EditorBrowsableState.Advanced)
                     );
                     b.AddCustomAttributes(nameof(ListDetailsView.ListPaneBackground), new CategoryAttribute(Resources.CategoryBrush));
+                    b.AddCustomAttributes(nameof(ListDetailsView.DetailsPaneBackground), new CategoryAttribute(Resources.CategoryBrush));
                     b.AddCustomAttributes(nameof(ListDetailsView.ListHeader), new CategoryAttribute(Resources.CategoryCommon));
                     b.AddCustomAttributes(nameof(ListDetailsView.ListHeaderTemplate),
                         new CategoryAttribute(Resources.CategoryAppearance),
@@ -33,6 +32,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
                     b.AddCustomAttributes(nameof(ListDetailsView.ListPaneWidth), new CategoryAttribute(Resources.CategoryAppearance));
                     b.AddCustomAttributes(nameof(ListDetailsView.NoSelectionContent), new CategoryAttribute(Resources.CategoryCommon));
                     b.AddCustomAttributes(nameof(ListDetailsView.NoSelectionContentTemplate),
+                        new CategoryAttribute(Resources.CategoryCommon),
+                        new EditorBrowsableAttribute(EditorBrowsableState.Advanced)
+                    );
+                    AddCustomAttributes(nameof(ListDetailsView.ListPaneNoItemsContent), new CategoryAttribute(Resources.CategoryCommon));
+                    b.AddCustomAttributes(nameof(ListDetailsView.ListPaneNoItemsContentTemplate),
                         new CategoryAttribute(Resources.CategoryCommon),
                         new EditorBrowsableAttribute(EditorBrowsableState.Advanced)
                     );

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Typedata.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Typedata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
 {
     internal static partial class ControlTypes
@@ -15,6 +13,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
     {
         internal const string DetailsCommandBar = nameof(DetailsCommandBar);
         internal const string DetailsTemplate = nameof(DetailsTemplate);
+        internal const string DetailsPaneBackground = nameof(DetailsPaneBackground);
+        internal const string DetailsContentTemplateSelector = nameof(DetailsContentTemplateSelector);
+        internal const string ListPaneItemTemplateSelector = nameof(ListPaneItemTemplateSelector);
+        internal const string ListPaneNoItemsContentTemplate = nameof(ListPaneNoItemsContentTemplate);
+        internal const string ListPaneNoItemsContent = nameof(ListPaneNoItemsContent);
         internal const string ListCommandBar = nameof(ListCommandBar);
         internal const string ListHeader = nameof(ListHeader);
         internal const string ListHeaderTemplate = nameof(ListHeaderTemplate);

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/BackButtonBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/BackButtonBehavior.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <remarks>
         /// If the back button controlled by <see cref="Windows.UI.Core.SystemNavigationManager"/> is already visible, the <see cref="ListDetailsView"/> will hook into that button.
-        /// If the new NavigationView provided by the Windows UI nuget package is used, the <see cref="ListDetailsView"/> will enable and show that button.
+        /// If the new NavigationView provided by the Windows UI NuGet package is used, the <see cref="ListDetailsView"/> will enable and show that button.
         /// Otherwise the inline button is used.
         /// </remarks>
         Automatic,

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
@@ -1,0 +1,166 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Windows.ApplicationModel;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Panel that allows for a List/Details pattern.
+    /// </summary>
+    /// <seealso cref="ItemsControl" />
+    public partial class ListDetailsView
+    {
+        private AppViewBackButtonVisibility? _previousSystemBackButtonVisibility;
+        private bool _previousNavigationViewBackEnabled;
+
+        // Int used because the underlying type is an enum, but we don't have access to the enum
+        private int _previousNavigationViewBackVisibilty;
+        private Button _inlineBackButton;
+        private object _navigationView;
+        private Frame _frame;
+
+        /// <summary>
+        /// Sets the back button visibility based on the current visual state and selected item
+        /// </summary>
+        private void SetBackButtonVisibility(ListDetailsViewState? previousState = null)
+        {
+            const int backButtonVisible = 1;
+
+            if (DesignMode.DesignModeEnabled)
+            {
+                return;
+            }
+
+            if (ViewState == ListDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                {
+                    _inlineBackButton.Visibility = Visibility.Visible;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    // Continue to support the system back button if it is being used
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
+                    {
+                        // Setting this indicates that the system back button is being used
+                        _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+                    }
+                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                    {
+                        // We can only use the new NavigationView if we also have a Frame
+                        // If there is no frame we have to use the inline button
+                        _inlineBackButton.Visibility = Visibility.Visible;
+                    }
+                    else
+                    {
+                        SetNavigationViewBackButtonState(backButtonVisible, true);
+                    }
+                }
+                else if (BackButtonBehavior != BackButtonBehavior.Manual)
+                {
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+
+                    navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
+                }
+            }
+            else if (previousState == ListDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                {
+                    _inlineBackButton.Visibility = Visibility.Collapsed;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    if (!_previousSystemBackButtonVisibility.HasValue)
+                    {
+                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                        {
+                            _inlineBackButton.Visibility = Visibility.Collapsed;
+                        }
+                        else
+                        {
+                            SetNavigationViewBackButtonState(_previousNavigationViewBackVisibilty, _previousNavigationViewBackEnabled);
+                        }
+                    }
+                }
+
+                if (_previousSystemBackButtonVisibility.HasValue)
+                {
+                    // Make sure we show the back button if the stack can navigate back
+                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousSystemBackButtonVisibility.Value;
+                    _previousSystemBackButtonVisibility = null;
+                }
+            }
+        }
+
+        private void SetNavigationViewBackButtonState(int visible, bool enabled)
+        {
+            if (_navigationView == null)
+            {
+                return;
+            }
+
+            System.Type navType = _navigationView.GetType();
+            PropertyInfo visibleProperty = navType.GetProperty("IsBackButtonVisible");
+            if (visibleProperty != null)
+            {
+                _previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(_navigationView);
+                visibleProperty.SetValue(_navigationView, visible);
+            }
+
+            PropertyInfo enabledProperty = navType.GetProperty("IsBackEnabled");
+            if (enabledProperty != null)
+            {
+                _previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(_navigationView);
+                enabledProperty.SetValue(_navigationView, enabled);
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
+        {
+            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == ListDetailsViewState.Details))
+            {
+                ClearSelectedItem();
+                args.Cancel = true;
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnBackRequested(object sender, BackRequestedEventArgs args)
+        {
+            if (ViewState == ListDetailsViewState.Details)
+            {
+                // let the OnFrameNavigating method handle it if
+                if (_frame == null || !_frame.CanGoBack)
+                {
+                    ClearSelectedItem();
+                }
+
+                args.Handled = true;
+            }
+        }
+
+        private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
+        {
+            ClearSelectedItem();
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (ViewState == ListDetailsViewState.Details)
             {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                if (BackButtonBehavior == BackButtonBehavior.Inline && _inlineBackButton != null)
                 {
                     _inlineBackButton.Visibility = Visibility.Visible;
                 }
@@ -53,7 +53,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         // Setting this indicates that the system back button is being used
                         _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
                     }
-                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                    else if (_inlineBackButton != null && (_navigationView == null || _frame == null))
                     {
                         // We can only use the new NavigationView if we also have a Frame
                         // If there is no frame we have to use the inline button
@@ -74,7 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
             else if (previousState == ListDetailsViewState.Details)
             {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                if (BackButtonBehavior == BackButtonBehavior.Inline && _inlineBackButton != null)
                 {
                     _inlineBackButton.Visibility = Visibility.Collapsed;
                 }
@@ -82,7 +82,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     if (!_previousSystemBackButtonVisibility.HasValue)
                     {
-                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                        if (_inlineBackButton != null && (_navigationView == null || _frame == null))
                         {
                             _inlineBackButton.Visibility = Visibility.Collapsed;
                         }
@@ -132,7 +132,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="args">The event args</param>
         private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
         {
-            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == ListDetailsViewState.Details))
+            if (args.NavigationMode == NavigationMode.Back && ViewState == ListDetailsViewState.Details)
             {
                 ClearSelectedItem();
                 args.Cancel = true;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Events.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Panel that allows for a List/Details pattern.
     /// </summary>
-    /// <seealso cref="Windows.UI.Xaml.Controls.ItemsControl" />
+    /// <seealso cref="ItemsControl" />
     public partial class ListDetailsView
     {
         /// <summary>
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public event SelectionChangedEventHandler SelectionChanged;
 
         /// <summary>
-        /// Occurs when the view state changes
+        /// Occurs when the view state changes.
         /// </summary>
         public event EventHandler<ListDetailsViewState> ViewStateChanged;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
@@ -106,21 +106,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="ListPaneNoItemsContent"/> dependency property.
+        /// Identifies the <see cref="ListPaneEmptyContent"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="ListPaneNoItemsContent"/> dependency property.</returns>
-        public static readonly DependencyProperty ListPaneNoItemsContentProperty = DependencyProperty.Register(
-            nameof(ListPaneNoItemsContent),
+        /// <returns>The identifier for the <see cref="ListPaneEmptyContent"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneEmptyContentProperty = DependencyProperty.Register(
+            nameof(ListPaneEmptyContent),
             typeof(object),
             typeof(ListDetailsView),
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.
+        /// Identifies the <see cref="ListPaneEmptyContentTemplate"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.</returns>
-        public static readonly DependencyProperty ListPaneNoItemsContentTemplateProperty = DependencyProperty.Register(
-            nameof(ListPaneNoItemsContentTemplate),
+        /// <returns>The identifier for the <see cref="ListPaneEmptyContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneEmptyContentTemplateProperty = DependencyProperty.Register(
+            nameof(ListPaneEmptyContentTemplate),
             typeof(DataTemplate),
             typeof(ListDetailsView),
             new PropertyMetadata(null));
@@ -321,10 +321,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>
         /// The content of the list pane's header. The default is null.
         /// </returns>
-        public object ListPaneNoItemsContent
+        public object ListPaneEmptyContent
         {
-            get { return GetValue(ListPaneNoItemsContentProperty); }
-            set { SetValue(ListPaneNoItemsContentProperty, value); }
+            get { return GetValue(ListPaneEmptyContentProperty); }
+            set { SetValue(ListPaneEmptyContentProperty, value); }
         }
 
         /// <summary>
@@ -333,10 +333,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>
         /// The template that specifies the visualization of the list pane no items object. The default is null.
         /// </returns>
-        public DataTemplate ListPaneNoItemsContentTemplate
+        public DataTemplate ListPaneEmptyContentTemplate
         {
-            get { return (DataTemplate)GetValue(ListPaneNoItemsContentTemplateProperty); }
-            set { SetValue(ListPaneNoItemsContentTemplateProperty, value); }
+            get { return (DataTemplate)GetValue(ListPaneEmptyContentTemplateProperty); }
+            set { SetValue(ListPaneEmptyContentTemplateProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
@@ -46,6 +46,36 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="DetailsContentTemplateSelector"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsContentTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsContentTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(DetailsContentTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneItemTemplateSelector"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneItemTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneItemTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(ListPaneItemTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="DetailsPaneBackground"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(DetailsPaneBackground),
+            typeof(Brush),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
         /// Identifies the <see cref="ListPaneBackground"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="ListPaneBackground"/> dependency property.</returns>
@@ -71,6 +101,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>The identifier for the <see cref="ListHeaderTemplate"/> dependency property.</returns>
         public static readonly DependencyProperty ListHeaderTemplateProperty = DependencyProperty.Register(
             nameof(ListHeaderTemplate),
+            typeof(DataTemplate),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneNoItemsContent"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneNoItemsContent"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneNoItemsContentProperty = DependencyProperty.Register(
+            nameof(ListPaneNoItemsContent),
+            typeof(object),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneNoItemsContentTemplateProperty = DependencyProperty.Register(
+            nameof(ListPaneNoItemsContentTemplate),
             typeof(DataTemplate),
             typeof(ListDetailsView),
             new PropertyMetadata(null));
@@ -103,7 +153,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(ListPaneWidth),
             typeof(double),
             typeof(ListDetailsView),
-            new PropertyMetadata(320d));
+            new PropertyMetadata(320d, OnListPaneWidthChanged));
 
         /// <summary>
         /// Identifies the <see cref="NoSelectionContent"/> dependency property.
@@ -162,7 +212,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(CompactModeThresholdWidth),
             typeof(double),
             typeof(ListDetailsView),
-            new PropertyMetadata(720d, OnCompactModeThresholdWidthChanged));
+            new PropertyMetadata(640d));
 
         /// <summary>
         /// Identifies the <see cref="BackButtonBehavior"/> dependency property
@@ -203,6 +253,35 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the details presenter.
+        /// </summary>
+        public DataTemplateSelector DetailsContentTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(DetailsContentTemplateSelectorProperty); }
+            set { SetValue(DetailsContentTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the list pane items.
+        /// </summary>
+        public DataTemplateSelector ListPaneItemTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(ListPaneItemTemplateSelectorProperty); }
+            set { SetValue(ListPaneItemTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the list pane's header
+        /// Gets or sets the Brush to apply to the background of the details area of the control.
+        /// </summary>
+        /// <returns>The Brush to apply to the background of the details area of the control.</returns>
+        public Brush DetailsPaneBackground
+        {
+            get { return (Brush)GetValue(DetailsPaneBackgroundProperty); }
+            set { SetValue(DetailsPaneBackgroundProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets the Brush to apply to the background of the list area of the control.
         /// </summary>
         /// <returns>The Brush to apply to the background of the list area of the control.</returns>
@@ -234,6 +313,30 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (DataTemplate)GetValue(ListHeaderTemplateProperty); }
             set { SetValue(ListHeaderTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the list pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The content of the list pane's header. The default is null.
+        /// </returns>
+        public object ListPaneNoItemsContent
+        {
+            get { return GetValue(ListPaneNoItemsContentProperty); }
+            set { SetValue(ListPaneNoItemsContentProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the list pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The template that specifies the visualization of the list pane no items object. The default is null.
+        /// </returns>
+        public DataTemplate ListPaneNoItemsContentTemplate
+        {
+            get { return (DataTemplate)GetValue(ListPaneNoItemsContentTemplateProperty); }
+            set { SetValue(ListPaneNoItemsContentTemplateProperty, value); }
         }
 
         /// <summary>
@@ -346,5 +449,81 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// This new model will be the DataContext of the Details area.
         /// </summary>
         public Func<object, object> MapDetails { get; set; }
+
+        /// <summary>
+        /// Fired when the DetailsCommandBar changes.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        private static void OnDetailsCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnDetailsCommandBarChanged();
+        }
+
+        /// <summary>
+        /// Fired when the <see cref="ListCommandBar"/> changes.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        private static void OnListCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnListCommandBarChanged();
+        }
+
+        /// <summary>
+        /// Fired when the SelectedItem changes.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        /// <remarks>
+        /// Sets up animations for the DetailsPresenter for animating in/out.
+        /// </remarks>
+        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnSelectedItemChanged(e);
+        }
+
+        /// <summary>
+        /// Fired when the SelectedIndex changes.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        /// <remarks>
+        /// Sets up animations for the DetailsPresenter for animating in/out.
+        /// </remarks>
+        private static void OnSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnSelectedIndexChanged(e);
+        }
+
+        /// <summary>
+        /// Fired when the <see cref="BackButtonBehavior"/> is changed.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).SetBackButtonVisibility();
+        }
+
+        /// <summary>
+        /// Fired when the <see cref="ListHeader"/> is changed.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        private static void OnListHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).SetListHeaderVisibility();
+        }
+
+        /// <summary>
+        /// Fired when the <see cref="ListPaneWidth"/> is changed.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
+        private static void OnListPaneWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnListPaneWidthChanged();
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -3,13 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using Windows.ApplicationModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Navigation;
 using NavigationView = Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -23,32 +21,32 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplateVisualState(Name = NoSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = HasSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = HasSelectionNarrowState, GroupName = SelectionStates)]
-    [TemplateVisualState(Name = NarrowState, GroupName = WidthStates)]
-    [TemplateVisualState(Name = WideState, GroupName = WidthStates)]
     public partial class ListDetailsView : ItemsControl
     {
-        private const string PartDetailsPresenter = "DetailsPresenter";
-        private const string PartDetailsPanel = "DetailsPanel";
-        private const string PartBackButton = "ListDetailsBackButton";
-        private const string PartHeaderContentPresenter = "HeaderContentPresenter";
-        private const string NarrowState = "NarrowState";
-        private const string WideState = "WideState";
-        private const string WidthStates = "WidthStates";
+        // All view states:
         private const string SelectionStates = "SelectionStates";
-        private const string HasSelectionNarrowState = "HasSelectionNarrow";
+        private const string NoSelectionWideState = "NoSelectionWide";
         private const string HasSelectionWideState = "HasSelectionWide";
         private const string NoSelectionNarrowState = "NoSelectionNarrow";
-        private const string NoSelectionWideState = "NoSelectionWide";
+        private const string HasSelectionNarrowState = "HasSelectionNarrow";
 
-        private AppViewBackButtonVisibility? _previousSystemBackButtonVisibility;
-        private bool _previousNavigationViewBackEnabled;
+        private const string HasItemsStates = "HasItemsStates";
+        private const string HasItemsState = "HasItemsState";
+        private const string HasNoItemsState = "HasNoItemsState";
 
-        private NavigationView.NavigationViewBackButtonVisible _previousNavigationViewBackVisibilty;
-        private NavigationView.NavigationView _navigationView;
+        // Control names:
+        private const string PartRootPanel = "RootPanel";
+        private const string PartDetailsPresenter = "DetailsPresenter";
+        private const string PartDetailsPanel = "DetailsPanel";
+        private const string PartMasterList = "MasterList";
+        private const string PartBackButton = "ListDetailsBackButton";
+        private const string PartHeaderContentPresenter = "HeaderContentPresenter";
+        private const string PartListPaneCommandBarPanel = "ListPaneCommandBarPanel";
+        private const string PartDetailsPaneCommandBarPanel = "DetailsPaneCommandBarPanel";
+
         private ContentPresenter _detailsPresenter;
+        private NavigationView.TwoPaneView _twoPaneView;
         private VisualStateGroup _selectionStateGroup;
-        private Button _inlineBackButton;
-        private Frame _frame;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListDetailsView"/> class.
@@ -59,6 +57,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+        }
+
+        /// <summary>
+        /// Clears the <see cref="SelectedItem"/> and prevent flickering of the UI if only the order of the items changed.
+        /// </summary>
+        public void ClearSelectedItem()
+        {
+            SelectedItem = null;
         }
 
         /// <summary>
@@ -81,15 +87,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _inlineBackButton.Click += OnInlineBackButtonClicked;
             }
 
+            _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
+            if (_selectionStateGroup != null)
+            {
+                _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
+            }
+
+            _twoPaneView = (NavigationView.TwoPaneView)GetTemplateChild(PartRootPanel);
+            if (_twoPaneView != null)
+            {
+                _twoPaneView.ModeChanged += OnModeChanged;
+            }
+
             _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
             SetDetailsContent();
 
             SetListHeaderVisibility();
             OnDetailsCommandBarChanged();
             OnListCommandBarChanged();
-
-            SizeChanged -= ListDetailsView_SizeChanged;
-            SizeChanged += ListDetailsView_SizeChanged;
+            OnListPaneWidthChanged();
 
             UpdateView(true);
         }
@@ -97,101 +113,61 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Fired when the SelectedIndex changes.
         /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
+        /// <param name="e">The event args.</param>
         /// <remarks>
         /// Sets up animations for the DetailsPresenter for animating in/out.
         /// </remarks>
-        private static void OnSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private void OnSelectedIndexChanged(DependencyPropertyChangedEventArgs e)
         {
-            var view = (ListDetailsView)d;
-
-            var newValue = (int)e.NewValue < 0 ? null : view.Items[(int)e.NewValue];
-            var oldValue = e.OldValue == null ? null : view.Items.ElementAtOrDefault((int)e.OldValue);
-
-            // check if selection actually changed
-            if (view.SelectedItem != newValue)
+            if (e.NewValue is int newIndex)
             {
-                // sync SelectedItem
-                view.SetValue(SelectedItemProperty, newValue);
-                view.UpdateSelection(oldValue, newValue);
+                object newItem = newIndex >= 0 && Items.Count > newIndex ? Items[newIndex] : null;
+                object oldItem = e.OldValue is int oldIndex && oldIndex >= 0 && Items.Count > oldIndex ? Items[oldIndex] : null;
+                if (SelectedItem != newItem)
+                {
+                    if (newItem is null)
+                    {
+                        ClearSelectedItem();
+                    }
+                    else
+                    {
+                        SetValue(SelectedItemProperty, newItem);
+                        UpdateSelection(oldItem, newItem);
+                    }
+                }
             }
         }
 
         /// <summary>
         /// Fired when the SelectedItem changes.
         /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
+        /// <param name="e">The event args.</param>
         /// <remarks>
         /// Sets up animations for the DetailsPresenter for animating in/out.
         /// </remarks>
-        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
         {
-            var view = (ListDetailsView)d;
-            var index = e.NewValue == null ? -1 : view.Items.IndexOf(e.NewValue);
+            int index = SelectedItem is null ? -1 : Items.IndexOf(SelectedItem);
 
-            // check if selection actually changed
-            if (view.SelectedIndex != index)
+            // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
+            if (index >= 0)
             {
-                // sync SelectedIndex
-                view.SetValue(SelectedIndexProperty, index);
-                view.UpdateSelection(e.OldValue, e.NewValue);
+                SetDetailsContent();
             }
-        }
 
-        /// <summary>
-        /// Fired when the <see cref="ListHeader"/> is changed.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnListHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.SetListHeaderVisibility();
-        }
+            if (SelectedIndex != index)
+            {
+                SetValue(SelectedIndexProperty, index);
+                UpdateSelection(e.OldValue, e.NewValue);
+            }
 
-        /// <summary>
-        /// Fired when the DetailsCommandBar changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnDetailsCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.OnDetailsCommandBarChanged();
-        }
-
-        /// <summary>
-        /// Fired when CompactModeThresholdWIdthChanged
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnCompactModeThresholdWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            ((ListDetailsView)d).HandleStateChanges();
-        }
-
-        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.SetBackButtonVisibility();
-        }
-
-        /// <summary>
-        /// Fired when the <see cref="ListCommandBar"/> changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnListCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.OnListCommandBarChanged();
+            OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
+            UpdateView(true);
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            if (DesignMode.DesignModeEnabled == false)
+            if (!DesignMode.DesignModeEnabled)
             {
                 SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
                 if (_frame != null)
@@ -205,14 +181,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _frame.Navigating += OnFrameNavigating;
                 }
-
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-                if (_selectionStateGroup != null)
-                {
-                    _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
-                }
-
-                UpdateView(true);
             }
         }
 
@@ -235,21 +203,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
-        private void ListDetailsView_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            // if size is changing
-            if ((e.PreviousSize.Width < CompactModeThresholdWidth && e.NewSize.Width >= CompactModeThresholdWidth) ||
-                (e.PreviousSize.Width >= CompactModeThresholdWidth && e.NewSize.Width < CompactModeThresholdWidth))
-            {
-                HandleStateChanges();
-            }
-        }
-
-        private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
-        {
-            SelectedItem = null;
-        }
-
         /// <summary>
         /// Raises SelectionChanged event and updates view.
         /// </summary>
@@ -265,45 +218,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (SelectedItem != null)
             {
                 SetDetailsContent();
-            }
-        }
-
-        private void HandleStateChanges()
-        {
-            UpdateView(true);
-            SetListSelectionWithKeyboardFocusOnVisualStateChanged(ViewState);
-        }
-
-        /// <summary>
-        /// Closes the details pane if we are in narrow state
-        /// </summary>
-        /// <param name="sender">The sender</param>
-        /// <param name="args">The event args</param>
-        private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
-        {
-            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == ListDetailsViewState.Details))
-            {
-                SelectedItem = null;
-                args.Cancel = true;
-            }
-        }
-
-        /// <summary>
-        /// Closes the details pane if we are in narrow state
-        /// </summary>
-        /// <param name="sender">The sender</param>
-        /// <param name="args">The event args</param>
-        private void OnBackRequested(object sender, BackRequestedEventArgs args)
-        {
-            if (ViewState == ListDetailsViewState.Details)
-            {
-                // let the OnFrameNavigating method handle it if
-                if (_frame == null || !_frame.CanGoBack)
-                {
-                    SelectedItem = null;
-                }
-
-                args.Handled = true;
             }
         }
 
@@ -323,88 +237,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetVisualState(animate);
         }
 
-        /// <summary>
-        /// Sets the back button visibility based on the current visual state and selected item
-        /// </summary>
-        private void SetBackButtonVisibility(ListDetailsViewState? previousState = null)
-        {
-            if (DesignMode.DesignModeEnabled)
-            {
-                return;
-            }
-
-            if (ViewState == ListDetailsViewState.Details)
-            {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
-                {
-                    _inlineBackButton.Visibility = Visibility.Visible;
-                }
-                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
-                {
-                    // Continue to support the system back button if it is being used
-                    var navigationManager = SystemNavigationManager.GetForCurrentView();
-                    if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
-                    {
-                        // Setting this indicates that the system back button is being used
-                        _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
-                    }
-                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
-                    {
-                        // We can only use the new NavigationView if we also have a Frame
-                        // If there is no frame we have to use the inline button
-                        _inlineBackButton.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        SetNavigationViewBackButtonState(NavigationView.NavigationViewBackButtonVisible.Visible, true);
-                    }
-                }
-                else if (BackButtonBehavior != BackButtonBehavior.Manual)
-                {
-                    var navigationManager = SystemNavigationManager.GetForCurrentView();
-                    _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
-
-                    navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
-                }
-            }
-            else if (previousState == ListDetailsViewState.Details)
-            {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
-                {
-                    _inlineBackButton.Visibility = Visibility.Collapsed;
-                }
-                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
-                {
-                    if (_previousSystemBackButtonVisibility.HasValue == false)
-                    {
-                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
-                        {
-                            _inlineBackButton.Visibility = Visibility.Collapsed;
-                        }
-                        else
-                        {
-                            SetNavigationViewBackButtonState(_previousNavigationViewBackVisibilty, _previousNavigationViewBackEnabled);
-                        }
-                    }
-                }
-
-                if (_previousSystemBackButtonVisibility.HasValue)
-                {
-                    // Make sure we show the back button if the stack can navigate back
-                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousSystemBackButtonVisibility.Value;
-                    _previousSystemBackButtonVisibility = null;
-                }
-            }
-        }
-
         private void UpdateViewState()
         {
-            var previousState = ViewState;
+            ListDetailsViewState previousState = ViewState;
 
-            if (ActualWidth < CompactModeThresholdWidth)
+            if (_twoPaneView == null)
+            {
+                ViewState = ListDetailsViewState.Both;
+            }
+
+            // Single pane:
+            else if (_twoPaneView.Mode == NavigationView.TwoPaneViewMode.SinglePane)
             {
                 ViewState = SelectedItem == null ? ListDetailsViewState.List : ListDetailsViewState.Details;
+                _twoPaneView.PanePriority = SelectedItem == null ? NavigationView.TwoPaneViewPriority.Pane1 : NavigationView.TwoPaneViewPriority.Pane2;
             }
+
+            // Dual pane:
             else
             {
                 ViewState = ListDetailsViewState.Both;
@@ -419,44 +268,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void SetVisualState(bool animate)
         {
-            string state;
             string noSelectionState;
             string hasSelectionState;
-            if (ActualWidth < CompactModeThresholdWidth)
+            if (ViewState == ListDetailsViewState.Both)
             {
-                state = NarrowState;
-                noSelectionState = NoSelectionNarrowState;
-                hasSelectionState = HasSelectionNarrowState;
-            }
-            else
-            {
-                state = WideState;
                 noSelectionState = NoSelectionWideState;
                 hasSelectionState = HasSelectionWideState;
             }
-
-            VisualStateManager.GoToState(this, state, animate);
-            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : hasSelectionState, animate);
-        }
-
-        private void SetNavigationViewBackButtonState(NavigationView.NavigationViewBackButtonVisible visibility, bool enabled)
-        {
-            if (_navigationView == null)
+            else
             {
-                return;
+                noSelectionState = NoSelectionNarrowState;
+                hasSelectionState = HasSelectionNarrowState;
             }
 
-            _previousNavigationViewBackVisibilty = _navigationView.IsBackButtonVisible;
-            _navigationView.IsBackButtonVisible = visibility;
-
-            _previousNavigationViewBackEnabled = _navigationView.IsBackEnabled;
-            _navigationView.IsBackEnabled = enabled;
+            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : hasSelectionState, animate);
+            VisualStateManager.GoToState(this, Items.Count > 0 ? HasItemsState : HasNoItemsState, animate);
         }
 
+        /// <summary>
+        /// Sets the content of the <see cref="SelectedItem"/> based on current <see cref="MapDetails"/> function.
+        /// </summary>
         private void SetDetailsContent()
         {
             if (_detailsPresenter != null)
             {
+                // Update the content template:
+                if (_detailsPresenter.ContentTemplateSelector != null)
+                {
+                    _detailsPresenter.ContentTemplate = _detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, _detailsPresenter);
+                }
+
+                // Update the content:
                 _detailsPresenter.Content = MapDetails == null
                     ? SelectedItem
                     : SelectedItem != null ? MapDetails(SelectedItem) : null;
@@ -465,12 +307,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnListCommandBarChanged()
         {
-            OnCommandBarChanged("ListCommandBarPanel", ListCommandBar);
+            OnCommandBarChanged("ListCommandBar", ListCommandBar);
         }
 
         private void OnDetailsCommandBarChanged()
         {
-            OnCommandBarChanged("DetailsCommandBarPanel", DetailsCommandBar);
+            OnCommandBarChanged("DetailsCommandBar", DetailsCommandBar);
         }
 
         private void OnCommandBarChanged(string panelName, CommandBar commandbar)
@@ -509,7 +351,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void SetListSelectionWithKeyboardFocus(bool singleSelectionFollowsFocus)
         {
-            if (GetTemplateChild("List") is Windows.UI.Xaml.Controls.ListViewBase list)
+            if (GetTemplateChild("List") is ListViewBase list)
             {
                 list.SingleSelectionFollowsFocus = singleSelectionFollowsFocus;
             }
@@ -563,10 +405,62 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusItemList()
         {
-            if (GetTemplateChild("List") is Control list)
+            if (GetTemplateChild("PartMasterList") is Control list)
             {
                 list.Focus(FocusState.Programmatic);
             }
+        }
+
+        /// <summary>
+        /// Fired when the <see cref="TwoPaneView"/> changed its view mode.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="args">The event args.</param>
+        private void OnModeChanged(NavigationView.TwoPaneView sender, object args)
+        {
+            UpdateView(true);
+            SetListSelectionWithKeyboardFocusOnVisualStateChanged(ViewState);
+        }
+
+        /// <summary>
+        /// Invoked once the items changed and ensures the visual state is constant.
+        /// </summary>
+        protected override void OnItemsChanged(object e)
+        {
+            base.OnItemsChanged(e);
+            UpdateView(true);
+
+            if (SelectedIndex < 0)
+            {
+                return;
+            }
+
+            // Ensure we still have the correct index and selected item for the new collection.
+            // This prevents flickering when the order of the collection changes.
+            int index = -1;
+            if (!(Items is null))
+            {
+                index = Items.IndexOf(SelectedItem);
+            }
+
+            if (index < 0)
+            {
+                ClearSelectedItem();
+            }
+            else if (SelectedIndex != index)
+            {
+                SetValue(SelectedIndexProperty, index);
+            }
+        }
+
+        /// <summary>
+        /// Updates the <see cref="TwoPaneView.Pane1Length"/> since it is of type <see cref="GridLength"/>,
+        /// but <see cref="ListPaneWidth"/> is of type <see cref="double"/>.
+        /// This should be changed in a further release.
+        /// </summary>
+        private void OnListPaneWidthChanged()
+        {
+            _twoPaneView.Pane1Length = new GridLength(ListPaneWidth);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Updates the <see cref="TwoPaneView.Pane1Length"/> since it is of type <see cref="GridLength"/>,
+        /// Updates the <see cref="TwoPaneView.Pane1Length"/> since it is of type 'GridLength',
         /// but <see cref="ListPaneWidth"/> is of type <see cref="double"/>.
         /// This should be changed in a further release.
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private const string PartRootPanel = "RootPanel";
         private const string PartDetailsPresenter = "DetailsPresenter";
         private const string PartDetailsPanel = "DetailsPanel";
-        private const string PartMasterList = "MasterList";
+        private const string PartMainList = "MainList";
         private const string PartBackButton = "ListDetailsBackButton";
         private const string PartHeaderContentPresenter = "HeaderContentPresenter";
         private const string PartListPaneCommandBarPanel = "ListPaneCommandBarPanel";
@@ -405,7 +405,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusItemList()
         {
-            if (GetTemplateChild("PartMasterList") is Control list)
+            if (GetTemplateChild("PartMainList") is Control list)
             {
                 list.Focus(FocusState.Programmatic);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls">
+                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+                    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <Style TargetType="controls:ListDetailsView">
         <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
@@ -13,99 +14,46 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid x:Name="RootPanel">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="ListColumn"
-                                                  Width="Auto" />
-                                <ColumnDefinition x:Name="DetailsColumn"
-                                                  Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid x:Name="ListPanel"
-                                  Width="{TemplateBinding ListPaneWidth}"
-                                  Background="{TemplateBinding ListPaneBackground}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="0,0,1,0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <ContentPresenter x:Name="HeaderContentPresenter"
-                                                  Margin="12,0"
-                                                  x:DeferLoadStrategy="Lazy"
-                                                  Content="{TemplateBinding ListHeader}"
-                                                  ContentTemplate="{TemplateBinding ListHeaderTemplate}"
-                                                  Visibility="Collapsed" />
-                                <ListView x:Name="List"
-                                          Grid.Row="1"
-                                          IsTabStop="False"
-                                          ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                                          ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
-                                          ItemTemplate="{TemplateBinding ItemTemplate}"
-                                          ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                          ItemsSource="{TemplateBinding ItemsSource}"
-                                          SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <Grid x:Name="ListCommandBarPanel" Grid.Row="2"></Grid>
-                            </Grid>
-                            <Grid x:Name="DetailsPanel"
-                                  Grid.Column="1">
-                                <ContentPresenter x:Name="NoSelectionPresenter"
-                                                  Content="{TemplateBinding NoSelectionContent}"
-                                                  ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
-                                <Grid x:Name="SelectionDetailsPanel">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="*" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <Grid Background="{TemplateBinding Background}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Button x:Name="ListDetailsBackButton"
-                                                Background="Transparent"
-                                                Height="44"
-                                                Width="48"
-                                                Visibility="Collapsed">
-                                            <SymbolIcon Symbol="Back"/>
-                                        </Button>
-                                        <ContentPresenter x:Name="DetailsHeaderPresenter"
-                                                          Content="{TemplateBinding DetailsHeader}"
-                                                          ContentTemplate="{TemplateBinding DetailsHeaderTemplate}"
-                                                          Grid.Column="1"/>
-                                    </Grid>
-                                    <ContentPresenter x:Name="DetailsPresenter"
-                                                      Background="{TemplateBinding Background}"
-                                                      ContentTemplate="{TemplateBinding DetailsTemplate}"
-                                                      Grid.Row="1">
-                                    </ContentPresenter>
-                                    <Grid x:Name="DetailsCommandBarPanel" Grid.Row="2"></Grid>
-                                    <Grid.RenderTransform>
-                                        <TranslateTransform x:Name="DetailsPresenterTransform" />
-                                    </Grid.RenderTransform>
-                                </Grid>
-                            </Grid>
-                        </Grid>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
+                                <VisualState x:Name="NoSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="NoSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="NoSelectionWide"
-                                                      To="HasSelection">
+                                                      To="HasSelectionWide">
                                         <Storyboard>
                                             <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPanel"
                                                                    ExitTargetName="NoSelectionPresenter" />
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition From="NoSelectionNarrow"
-                                                      To="HasSelection">
+                                                      To="HasSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
                                                              Storyboard.TargetName="DetailsPresenterTransform"
                                                              Storyboard.TargetProperty="X"
                                                              From="200"
                                                              To="0"
-                                                             Duration="0:0:0.25">
+                                                             Duration="0:0:0.17">
                                                 <DoubleAnimation.EasingFunction>
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
@@ -115,93 +63,155 @@
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
-                                                             Duration="0:0:0.25">
+                                                             Duration="0:0:0.17">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <QuarticEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                            <DoubleAnimation BeginTime="0:0:0"
+                                                             Storyboard.TargetName="NoSelectionPresenter"
+                                                             Storyboard.TargetProperty="Opacity"
+                                                             From="1"
+                                                             To="0"
+                                                             Duration="0:0:0">
                                                 <DoubleAnimation.EasingFunction>
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection"
+                                    <VisualTransition From="HasSelectionWide"
                                                       To="NoSelectionWide">
                                         <Storyboard>
                                             <DrillOutThemeAnimation EntranceTargetName="NoSelectionPresenter"
                                                                     ExitTargetName="SelectionDetailsPanel" />
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection"
+                                    <VisualTransition From="HasSelectionNarrow"
                                                       To="NoSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="DetailsPresenterTransform"
+                                                             Storyboard.TargetName="MasterPresenterTransform"
                                                              Storyboard.TargetProperty="X"
-                                                             From="0"
-                                                             To="200"
-                                                             Duration="0:0:0.25" />
-                                            <DoubleAnimation BeginTime="0:0:0.08"
-                                                             Storyboard.TargetName="SelectionDetailsPanel"
-                                                             Storyboard.TargetProperty="Opacity"
-                                                             From="1"
+                                                             From="-200"
                                                              To="0"
                                                              Duration="0:0:0.17">
                                                 <DoubleAnimation.EasingFunction>
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
-                                            <DoubleAnimation BeginTime="0:0:0.0"
+                                            <DoubleAnimation BeginTime="0:0:0"
                                                              Storyboard.TargetName="ListPanel"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
-                                                             Duration="0:0:0.25">
+                                                             Duration="0:0:0.17">
                                                 <DoubleAnimation.EasingFunction>
-                                                    <QuarticEase EasingMode="EaseIn" />
+                                                    <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="NoSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="ListPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="NoSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="WidthStates">
-                                <VisualState x:Name="NarrowState">
+
+                            <VisualStateGroup x:Name="HasItemsStates">
+                                <VisualState x:Name="HasItemsState">
                                     <VisualState.Setters>
-                                        <Setter Target="ListColumn.Width" Value="*" />
-                                        <Setter Target="DetailsColumn.Width" Value="0" />
-                                        <Setter Target="DetailsPanel.(Grid.Column)" Value="0" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.BorderThickness" Value="0" />
-                                        <Setter Target="ListPanel.Width" Value="NaN" />
+                                        <Setter Target="MasterList.Visibility" Value="Visible" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="WideState">
+                                <VisualState x:Name="HasNoItemsState">
+                                    <VisualState.Setters>
+                                        <Setter Target="MasterList.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
+                        <muxc:TwoPaneView x:Name="RootPanel"
+                                          MinWideModeWidth="{TemplateBinding CompactModeThresholdWidth}"
+                                          PanePriority="Pane1"
+                                          TallModeConfiguration="SinglePane"
+                                          WideModeConfiguration="LeftRight">
+                            <muxc:TwoPaneView.Pane1>
+                                <Grid x:Name="ListPanel"
+                                      Background="{TemplateBinding ListPaneBackground}">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <ContentPresenter x:Name="HeaderContentPresenter"
+                                                      Margin="12,0"
+                                                      x:DeferLoadStrategy="Lazy"
+                                                      Content="{TemplateBinding ListHeader}"
+                                                      ContentTemplate="{TemplateBinding ListHeaderTemplate}"
+                                                      Visibility="Collapsed" />
+                                    <ContentPresenter x:Name="MasterNoItemsPresenter"
+                                                      Grid.Row="1"
+                                                      Content="{TemplateBinding ListPaneNoItemsContent}"
+                                                      ContentTemplate="{TemplateBinding ListPaneNoItemsContentTemplate}" />
+                                    <ListView x:Name="MasterList"
+                                              Grid.Row="1"
+                                              IsTabStop="False"
+                                              ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                              ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
+                                              ItemTemplate="{TemplateBinding ItemTemplate}"
+                                              ItemTemplateSelector="{TemplateBinding ListPaneItemTemplateSelector}"
+                                              ItemsSource="{TemplateBinding ItemsSource}"
+                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Visibility="Collapsed" />
+                                    <Grid x:Name="ListCommandBar"
+                                          Grid.Row="2" />
+                                    <Grid.RenderTransform>
+                                        <TranslateTransform x:Name="MasterPresenterTransform" />
+                                    </Grid.RenderTransform>
+                                </Grid>
+                            </muxc:TwoPaneView.Pane1>
+                            <muxc:TwoPaneView.Pane2>
+                                <Grid x:Name="DetailsPanel"
+                                      Background="{TemplateBinding DetailsPaneBackground}">
+                                    <ContentPresenter x:Name="NoSelectionPresenter"
+                                                      Content="{TemplateBinding NoSelectionContent}"
+                                                      ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
+                                    <Grid x:Name="SelectionDetailsPanel">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Button x:Name="ListDetailsBackButton"
+                                                    Width="48"
+                                                    Height="44"
+                                                    Background="Transparent"
+                                                    Visibility="Collapsed">
+                                                <SymbolIcon Symbol="Back" />
+                                            </Button>
+                                            <ContentPresenter x:Name="DetailsHeaderPresenter"
+                                                              Grid.Column="1"
+                                                              Content="{TemplateBinding DetailsHeader}"
+                                                              ContentTemplate="{TemplateBinding DetailsHeaderTemplate}" />
+                                        </Grid>
+                                        <ContentPresenter x:Name="DetailsPresenter"
+                                                          Grid.Row="1"
+                                                          ContentTemplate="{TemplateBinding DetailsTemplate}"
+                                                          ContentTemplateSelector="{TemplateBinding DetailsContentTemplateSelector}" />
+                                        <Grid x:Name="DetailsCommandBar"
+                                              Grid.Row="2" />
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform x:Name="DetailsPresenterTransform" />
+                                        </Grid.RenderTransform>
+                                    </Grid>
+                                </Grid>
+                            </muxc:TwoPaneView.Pane2>
+                        </muxc:TwoPaneView>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
@@ -91,7 +91,7 @@
                                                       To="NoSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="MasterPresenterTransform"
+                                                             Storyboard.TargetName="ListPresenterTransform"
                                                              Storyboard.TargetProperty="X"
                                                              From="-200"
                                                              To="0"
@@ -118,14 +118,14 @@
                             <VisualStateGroup x:Name="HasItemsStates">
                                 <VisualState x:Name="HasItemsState">
                                     <VisualState.Setters>
-                                        <Setter Target="MasterList.Visibility" Value="Visible" />
-                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MainList.Visibility" Value="Visible" />
+                                        <Setter Target="MainListEmptyItemsPresenter.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="HasNoItemsState">
                                     <VisualState.Setters>
-                                        <Setter Target="MasterList.Visibility" Value="Collapsed" />
-                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Visible" />
+                                        <Setter Target="MainList.Visibility" Value="Collapsed" />
+                                        <Setter Target="MainListEmptyItemsPresenter.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -149,11 +149,11 @@
                                                       Content="{TemplateBinding ListHeader}"
                                                       ContentTemplate="{TemplateBinding ListHeaderTemplate}"
                                                       Visibility="Collapsed" />
-                                    <ContentPresenter x:Name="MasterNoItemsPresenter"
+                                    <ContentPresenter x:Name="MainListEmptyItemsPresenter"
                                                       Grid.Row="1"
-                                                      Content="{TemplateBinding ListPaneNoItemsContent}"
-                                                      ContentTemplate="{TemplateBinding ListPaneNoItemsContentTemplate}" />
-                                    <ListView x:Name="MasterList"
+                                                      Content="{TemplateBinding ListPaneEmptyContent}"
+                                                      ContentTemplate="{TemplateBinding ListPaneEmptyContentTemplate}" />
+                                    <ListView x:Name="MainList"
                                               Grid.Row="1"
                                               IsTabStop="False"
                                               ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
@@ -166,7 +166,7 @@
                                     <Grid x:Name="ListCommandBar"
                                           Grid.Row="2" />
                                     <Grid.RenderTransform>
-                                        <TranslateTransform x:Name="MasterPresenterTransform" />
+                                        <TranslateTransform x:Name="ListPresenterTransform" />
                                     </Grid.RenderTransform>
                                 </Grid>
                             </muxc:TwoPaneView.Pane1>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsViewState.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsViewState.cs
@@ -10,17 +10,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public enum ListDetailsViewState
     {
         /// <summary>
-        /// Only the List view is shown
+        /// Only the List view is shown-
         /// </summary>
         List,
 
         /// <summary>
-        /// Only the Details view is shown
+        /// Only the Details view is shown-
         /// </summary>
         Details,
 
         /// <summary>
-        /// Both the List and Details views are shown
+        /// Both the List and Details views are shown-
         /// </summary>
         Both
     }

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView.cs
@@ -5,9 +5,10 @@
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace UnitTests.UWP.UI.Controls
+namespace UnitTests.UI.Controls
 {
     [TestClass]
     public class Test_ListDetailsView
@@ -17,8 +18,10 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_SelectedIndex_Default()
         {
             var items = Enumerable.Range(1, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items
+            };
             Assert.AreEqual(-1, listDetailsView.SelectedIndex);
         }
 
@@ -27,8 +30,10 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_SelectedItem_Default()
         {
             var items = Enumerable.Range(1, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items
+            };
             Assert.IsNull(listDetailsView.SelectedItem);
         }
 
@@ -37,9 +42,11 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_SelectedIndex_Syncs_SelectedItem()
         {
             var items = Enumerable.Range(1, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
-            listDetailsView.SelectedIndex = 6;
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedIndex = 6
+            };
             Assert.AreEqual(items[6], listDetailsView.SelectedItem);
         }
 
@@ -48,9 +55,11 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_UnselectUsingIndex()
         {
             var items = Enumerable.Range(1, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
-            listDetailsView.SelectedIndex = 5;
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedIndex = 5
+            };
             listDetailsView.SelectedIndex = -1;
             Assert.IsNull(listDetailsView.SelectedItem);
         }
@@ -60,9 +69,11 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_UnselectUsingItem()
         {
             var items = Enumerable.Range(1, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
-            listDetailsView.SelectedItem = items[5];
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedItem = items[5]
+            };
             listDetailsView.SelectedItem = null;
             Assert.AreEqual(-1, listDetailsView.SelectedIndex);
         }
@@ -72,10 +83,57 @@ namespace UnitTests.UWP.UI.Controls
         public void Test_SelectedItem_Syncs_SelectedIndex()
         {
             var items = Enumerable.Range(0, 10).ToArray();
-            var listDetailsView = new ListDetailsView();
-            listDetailsView.ItemsSource = items;
-            listDetailsView.SelectedItem = items[3];
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedItem = items[3]
+            };
             Assert.AreEqual(3, listDetailsView.SelectedIndex);
+        }
+
+        [TestCategory("ListDetailsView")]
+        [UITestMethod]
+        public void Test_Sorting_Keeps_SelectedIndex()
+        {
+            var items = Enumerable.Range(0, 10).ToArray();
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedItem = items[3]
+            };
+            Assert.AreEqual(3, listDetailsView.SelectedIndex);
+        }
+
+        [TestCategory("ListDetailsView")]
+        [UITestMethod]
+        public void Test_Sorting_Keeps_SelectedItem()
+        {
+            var items = new ObservableCollection<int>(Enumerable.Range(0, 10));
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedIndex = 3
+            };
+            var item = listDetailsView.SelectedItem;
+            listDetailsView.ItemsSource = new ObservableCollection<int>(items.OrderByDescending(i => i));
+            Assert.AreEqual(item, listDetailsView.SelectedItem);
+            listDetailsView.ItemsSource = new ObservableCollection<int>(items.OrderBy(i => i));
+            Assert.AreEqual(item, listDetailsView.SelectedItem);
+        }
+
+        [TestCategory("ListDetailsView")]
+        [UITestMethod]
+        public void Test_ItemsRemoved()
+        {
+            var items = new ObservableCollection<int>(Enumerable.Range(0, 10));
+            var listDetailsView = new ListDetailsView
+            {
+                ItemsSource = items,
+                SelectedIndex = 3
+            };
+            listDetailsView.ItemsSource = null;
+            Assert.AreEqual(null, listDetailsView.SelectedItem);
+            Assert.AreEqual(-1, listDetailsView.SelectedIndex);
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
- Refactoring
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
The [ListDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) does not take advantage of multiple screens and is not spanning aware.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
The new and refactored [ListDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) control is aware of multiple screens.
We archive this by replacing the current `grid`-based layout with the new [Two-pane view](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/two-pane-view) based layout.

<!-- Describe how was this issue resolved or changed? -->

## Additional changes
- I added additional properties: `DetailsPaneBackground`, `DetailsContentTemplateSelector`, `ListPaneEmptyContent`, `ListPaneEmptyContentTemplate` and `ListPaneItemTemplateSelector`.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: [#559](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/559)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information
### Old behavior
![Old Toolkit](https://user-images.githubusercontent.com/11741404/77059461-408ba480-69d7-11ea-9e68-9d15d299d7f2.png)

### New behavior 
![New Toolkit](https://user-images.githubusercontent.com/11741404/77059480-47b2b280-69d7-11ea-8b3a-d7522a2c2c42.png)