### PR TITLE
Fix and enable MVVM Toolkit source generator unit tests

### DIFF
--- a/UnitTests/UnitTests.SourceGenerators/Test_SourceGeneratorsDiagnostics.cs
+++ b/UnitTests/UnitTests.SourceGenerators/Test_SourceGeneratorsDiagnostics.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.SourceGenerators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -249,6 +250,7 @@ namespace UnitTests.Mvvm
         private void VerifyGeneratedDiagnostics<TGenerator>(string source, params string[] diagnosticsIds)
             where TGenerator : class, ISourceGenerator, new()
         {
+            Type observableObjectType = typeof(ObservableObject);
             Type validationAttributeType = typeof(ValidationAttribute);
 
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
@@ -271,6 +273,7 @@ namespace UnitTests.Mvvm
 
             Assert.IsTrue(resultingIds.SetEquals(diagnosticsIds));
 
+            GC.KeepAlive(observableObjectType);
             GC.KeepAlive(validationAttributeType);
         }
     }

--- a/UnitTests/UnitTests.SourceGenerators/UnitTests.SourceGenerators.csproj
+++ b/UnitTests/UnitTests.SourceGenerators/UnitTests.SourceGenerators.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Toolkit.Mvvm.SourceGenerators\Microsoft.Toolkit.Mvvm.SourceGenerators.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Toolkit.Mvvm\Microsoft.Toolkit.Mvvm.csproj" />
   </ItemGroup>
 
 </Project>

--- a/build/build.cake
+++ b/build/build.cake
@@ -270,6 +270,18 @@ Task("Test")
         ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings /p:Platform=AnyCPU"),
     };
     DotNetCoreTest(file.FullPath, testSettings);
+}).DoesForEach(GetFiles(baseDir + "/**/UnitTests.SourceGenerators.csproj"), (file) =>
+{
+    Information("\nRunning NetCore Source Generator Unit Tests");
+    var testSettings = new DotNetCoreTestSettings
+    {
+        Configuration = configuration,
+        NoBuild = true,
+        Loggers = new[] { "trx;LogFilePrefix=VsTestResults" },
+        Verbosity = DotNetCoreVerbosity.Normal,
+        ArgumentCustomization = arg => arg.Append($"-s {baseDir}/.runsettings /p:Platform=AnyCPU"),
+    };
+    DotNetCoreTest(file.FullPath, testSettings);
 }).DeferOnError();
 
 Task("UITest")


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
The unit tests for the MVVM Toolkit source generator are broken and also don't run in the CI.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Fixed the unit tests and enabled them in the CI.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes