### PR TITLE
Fixed [ObservableProperty] for fields named "value"

### DIFF
--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -119,6 +119,42 @@ namespace UnitTests.Mvvm
             Assert.AreEqual(testAttribute.Animal, Animal.Llama);
         }
 
+        // See https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4216
+        [TestCategory("Mvvm")]
+        [TestMethod]
+        public void Test_ObservablePropertyWithValueNamedField()
+        {
+            var model = new ModelWithValueProperty();
+
+            List<string?> propertyNames = new();
+
+            model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+            model.Value = "Hello world";
+
+            Assert.AreEqual(model.Value, "Hello world");
+
+            CollectionAssert.AreEqual(new[] { nameof(model.Value) }, propertyNames);
+        }
+
+        // See https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4216
+        [TestCategory("Mvvm")]
+        [TestMethod]
+        public void Test_ObservablePropertyWithValueNamedField_WithValidationAttributes()
+        {
+            var model = new ModelWithValuePropertyWithValidation();
+
+            List<string?> propertyNames = new();
+
+            model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+            model.Value = "Hello world";
+
+            Assert.AreEqual(model.Value, "Hello world");
+
+            CollectionAssert.AreEqual(new[] { nameof(model.Value) }, propertyNames);
+        }
+
         public partial class SampleModel : ObservableObject
         {
             /// <summary>
@@ -194,6 +230,20 @@ namespace UnitTests.Mvvm
             Cat,
             Dog,
             Llama
+        }
+
+        public partial class ModelWithValueProperty : ObservableObject
+        {
+            [ObservableProperty]
+            private string value;
+        }
+
+        public partial class ModelWithValuePropertyWithValidation : ObservableValidator
+        {
+            [ObservableProperty]
+            [Required]
+            [MinLength(5)]
+            private string value;
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Closes #4216

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
Using `[ObservableProperty]` on a field named "value" results in incorrect generated code.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
The generated code now works as expected.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] New component
  - [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [X] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [X] If control, added to Visual Studio Design project
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
