### PR TITLE
Fixed ValidateAllProperties generation for generated properties

### DIFF
--- a/Microsoft.Toolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
+++ b/Microsoft.Toolkit.Mvvm.SourceGenerators/ComponentModel/ObservablePropertyGenerator.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Toolkit.Mvvm.SourceGenerators
         /// <param name="fieldSymbol">The input <see cref="IFieldSymbol"/> instance to process.</param>
         /// <returns>The generated property name for <paramref name="fieldSymbol"/>.</returns>
         [Pure]
-        private static string GetGeneratedPropertyName(IFieldSymbol fieldSymbol)
+        public static string GetGeneratedPropertyName(IFieldSymbol fieldSymbol)
         {
             string propertyName = fieldSymbol.Name;
 

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -155,6 +156,33 @@ namespace UnitTests.Mvvm
             CollectionAssert.AreEqual(new[] { nameof(model.Value) }, propertyNames);
         }
 
+        // See https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4184
+        [TestCategory("Mvvm")]
+        [TestMethod]
+        public void Test_GeneratedPropertiesWithValidationAttributesOverFields()
+        {
+            var model = new ViewModelWithValidatableGeneratedProperties();
+
+            List<string?> propertyNames = new();
+
+            model.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+            // Assign these fields directly to bypass the validation that is executed in the generated setters.
+            // We only need those generated properties to be there to check whether they are correctly detected.
+            model.first = "A";
+            model.last = "This is a very long name that exceeds the maximum length of 60 for this property";
+
+            Assert.IsFalse(model.HasErrors);
+
+            model.RunValidation();
+
+            Assert.IsTrue(model.HasErrors);
+
+            ValidationResult[] validationErrors = model.GetErrors().ToArray();
+
+            Assert.AreEqual(validationErrors.Length, 2);
+        }
+
         public partial class SampleModel : ObservableObject
         {
             /// <summary>
@@ -244,6 +272,25 @@ namespace UnitTests.Mvvm
             [Required]
             [MinLength(5)]
             private string value;
+        }
+  
+        public partial class ViewModelWithValidatableGeneratedProperties : ObservableValidator
+        {
+            [Required]
+            [MinLength(2)]
+            [MaxLength(60)]
+            [Display(Name = "FirstName")]
+            [ObservableProperty]
+            public string first = "Bob";
+
+            [Display(Name = "LastName")]
+            [Required]
+            [MinLength(2)]
+            [MaxLength(60)]
+            [ObservableProperty]
+            public string last = "Jones";
+
+            public void RunValidation() => ValidateAllProperties();
         }
     }
 }

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -181,6 +181,9 @@ namespace UnitTests.Mvvm
             ValidationResult[] validationErrors = model.GetErrors().ToArray();
 
             Assert.AreEqual(validationErrors.Length, 2);
+
+            CollectionAssert.AreEqual(new[] { nameof(ViewModelWithValidatableGeneratedProperties.First) }, validationErrors[0].MemberNames.ToArray());
+            CollectionAssert.AreEqual(new[] { nameof(ViewModelWithValidatableGeneratedProperties.Last) }, validationErrors[1].MemberNames.ToArray());
         }
 
         public partial class SampleModel : ObservableObject


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4184

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
> "If you annotate a field with `ObservableProperty` along with validation attributes, the generated source code for the `ValidateAllProperties` method doesn't include all the properties."
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
The generated code for `ValidateAllProperties` is now correct.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] New component
  - [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [X] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [X] If control, added to Visual Studio Design project
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
