### PR TITLE
Fix #4214 - Update AttachedDropShadow visual on layout/visibility

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Toolkit.Uwp.UI
 
         private Dictionary<string, object> _resources;
 
+        internal long? VisibilityToken { get; set; }
+
         /// <summary>
         /// Gets a value indicating whether or not this <see cref="AttachedShadowElementContext"/> has been initialized.
         /// </summary>


### PR DESCRIPTION
## Fixes 4214

We weren't updating the shadow visual if the parent element's visibility changed or layout was effected by other elements.

## PR Type

- Bugfix

## What is the current behavior?

In some scenarios the shadow wouldn't be updated by the changes to the parent element.

## What is the new behavior?

Shadow is now updated in more scenarios (though maybe not all). We should properly handle `Visibility`, `Scale`, and some changes due to Layout updates.

Note: I tried with `Canvas` from the implicit animation sample and it seems Canvas moving an object doesn't call `LayoutUpdated` on that element... wonder if that's a framework bug ([this was the closest open one I could find](https://github.com/microsoft/microsoft-ui-xaml/issues/2900))? Otherwise, not sure how we detect that in the element...

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

@zateutsch you hadn't attached your sample project. Did you want to see if the [Preview Package](https://aka.ms/wct/wiki/previewpackages) spit out by the CI works in your test project?