### PR TITLE
Fixed [AlsoNotifyChangeFor] attribute definition

### DIFF
--- a/Microsoft.Toolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyChangeForAttribute.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/Attributes/AlsoNotifyChangeForAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -67,7 +67,7 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
     /// }
     /// </code>
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
     public sealed class AlsoNotifyChangeForAttribute : Attribute
     {
         /// <summary>
@@ -87,7 +87,7 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
         /// The other property names to also notify when the annotated property changes. This parameter can optionally
         /// be used to indicate a series of dependent properties from the same attribute, to keep the code more compact.
         /// </param>
-        public AlsoNotifyChangeForAttribute(string propertyName, string[] otherPropertyNames)
+        public AlsoNotifyChangeForAttribute(string propertyName, params string[] otherPropertyNames)
         {
             PropertyNames = new[] { propertyName }.Concat(otherPropertyNames).ToArray();
         }

--- a/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
+++ b/UnitTests/UnitTests.NetCore/Mvvm/Test_ObservablePropertyAttribute.cs
@@ -71,7 +71,7 @@ namespace UnitTests.Mvvm
             model.Name = "Bob";
             model.Surname = "Ross";
 
-            CollectionAssert.AreEqual(new[] { nameof(model.Name), nameof(model.FullName), nameof(model.Surname), nameof(model.FullName) }, propertyNames);
+            CollectionAssert.AreEqual(new[] { nameof(model.Name), nameof(model.FullName), nameof(model.Alias), nameof(model.Surname), nameof(model.FullName), nameof(model.Alias) }, propertyNames);
         }
 
         [TestCategory("Mvvm")]
@@ -169,13 +169,16 @@ namespace UnitTests.Mvvm
         {
             [ObservableProperty]
             [AlsoNotifyChangeFor(nameof(FullName))]
+            [AlsoNotifyChangeFor(nameof(Alias))]
             private string? name;
 
             [ObservableProperty]
-            [AlsoNotifyChangeFor(nameof(FullName))]
+            [AlsoNotifyChangeFor(nameof(FullName), nameof(Alias))]
             private string? surname;
 
             public string FullName => $"{Name} {Surname}";
+
+            public string Alias => $"{Name?.ToLower()}{Surname?.ToLower()}";
         }
 
         public partial class MyFormViewModel : ObservableValidator


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
The `[AlsoNotifyChangeFor]` attribute can't be used multiple types, and a constructor is missing `params`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Fixed the issues mentioned above.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] New component
  - [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [X] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [X] If control, added to Visual Studio Design project
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
