### PR TITLE
Upgraded Dismiss button to be legible at 225% text display setting

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
@@ -265,7 +265,7 @@
                         VerticalAlignment="Center"
                         Visibility="{Binding ShowDismissButton, ElementName=ExampleCustomInAppNotification}">
                       <Button.RenderTransform>
-                          <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="1"/>
+                        <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="1"/>
                       </Button.RenderTransform>
                     </Button>
                   </Grid>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
@@ -110,6 +110,7 @@
                 <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
                 <Setter Property="Width" Value="40" />
                 <Setter Property="Height" Value="40" />
+                <Setter Property="Padding" Value="4" />
                 <Setter Property="UseSystemFocusVisuals" Value="True" />
                 <Setter Property="HighContrastAdjustment" Value="None" />
                 <Setter Property="Template">
@@ -264,7 +265,7 @@
                         VerticalAlignment="Center"
                         Visibility="{Binding ShowDismissButton, ElementName=ExampleCustomInAppNotification}">
                       <Button.RenderTransform>
-                        <TranslateTransform x:Name="DismissButtonTransform" X="25" Y="-5"/>
+                          <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="1"/>
                       </Button.RenderTransform>
                     </Button>
                   </Grid>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -43,6 +43,7 @@
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
         <Setter Property="Width" Value="{StaticResource SystemControlMSEdgeNotificationDismissButtonSize}" />
         <Setter Property="Height" Value="{StaticResource SystemControlMSEdgeNotificationDismissButtonSize}" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="HighContrastAdjustment" Value="None" />
         <Setter Property="Template">
@@ -150,9 +151,10 @@
                         FontFamily="Segoe MDL2 Assets"
                         FontSize="12"
                         VerticalAlignment="Top"
+                        Padding="4"
                         Style="{StaticResource DismissTextBlockButtonStyle}">
                     <Button.RenderTransform>
-                        <TranslateTransform x:Name="DismissButtonTransform" X="25" Y="-5"/>
+                        <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="2"/>
                     </Button.RenderTransform>
                 </Button>
             </Grid>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -154,7 +154,7 @@
                         Padding="4"
                         Style="{StaticResource DismissTextBlockButtonStyle}">
                     <Button.RenderTransform>
-                        <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="2"/>
+                        <TranslateTransform x:Name="DismissButtonTransform" X="20" Y="1"/>
                     </Button.RenderTransform>
                 </Button>
             </Grid>


### PR DESCRIPTION
## Fixes #3467



## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

The 'X' inside the Dismiss button, becomes off-center and generally unreadable when user sets Windows text display to 225%

## What is the new behavior?

The 'X' inside the Dismiss button is legible at Windows text display setting of 225%

![image](https://user-images.githubusercontent.com/86266896/133513756-275b8ceb-8a00-4cb9-9655-c47e1e2300a1.png)


## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
