### PR TITLE
Fixed culture sensitivity when parsing AspectRatio components

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/AspectRatio.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/AspectRatio.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Globalization;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -75,11 +75,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (ratio.Length == 2)
             {
-                return new AspectRatio(Convert.ToDouble(ratio[0]), Convert.ToDouble(ratio[1]));
+                double width = double.Parse(ratio[0], NumberStyles.Float, CultureInfo.InvariantCulture);
+                double height = double.Parse(ratio[1], NumberStyles.Float, CultureInfo.InvariantCulture);
+
+                return new AspectRatio(width, height);
             }
             else if (ratio.Length == 1)
             {
-                return new AspectRatio(Convert.ToDouble(ratio[0]));
+                return new AspectRatio(double.Parse(ratio[0], NumberStyles.Float, CultureInfo.InvariantCulture));
             }
 
             return new AspectRatio(1);

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.Properties.cs
@@ -2,14 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Foundation;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/ConstrainedBox/ConstrainedBox.cs
@@ -3,10 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.Alignment.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
-using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.AspectRatio.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ConstrainedBox.AspectRatio.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
-using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
@@ -91,6 +89,77 @@ namespace UnitTests.UWP.UI.Controls
                 Assert.AreEqual(100, child.ActualWidth, 0.01, "Actual width does not meet expected value of 100");
                 Assert.AreEqual(200, child.ActualHeight, 0.01, "Actual height does not meet expected value of 200");
             });
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public void Test_ConstrainedBox_AspectRatioParsing_WidthAndHeight()
+        {
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
+                AspectRatio ratio = AspectRatio.ConvertToAspectRatio("1.666:1.2");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1.2);
+
+                // Explicit tests for other culture infos, see https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4252
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("it-IT");
+
+                ratio = AspectRatio.ConvertToAspectRatio("1.666:1.2");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1.2);
+
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+
+                ratio = AspectRatio.ConvertToAspectRatio("1.666:1.2");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1.2);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+            }
+        }
+
+        [TestCategory("ConstrainedBox")]
+        [TestMethod]
+        public void Test_ConstrainedBox_AspectRatioParsing_Ratio()
+        {
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
+                AspectRatio ratio = AspectRatio.ConvertToAspectRatio("1.666");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1);
+
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("it-IT");
+
+                ratio = AspectRatio.ConvertToAspectRatio("1.666");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1);
+
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+
+                ratio = AspectRatio.ConvertToAspectRatio("1.666");
+
+                Assert.AreEqual(ratio.Width, 1.666);
+                Assert.AreEqual(ratio.Height, 1);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4252

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
The `AspectRatio.ConvertToAspectRatio(string)` method used for parsing is using `Convert.ToDouble`, which by default uses the current culture for parsing. This causes a crash when trying to parse a number using `'.'` as decimal separator on cultures that instead use `','` as decimal separator (eg. French, Italian). Furthermore, the parsing behavior is not consistent with eg. the various `Vector2/3/4` and `Quaternion` parsing APIs in the `StringExtensions` class in `Microsoft.Toolkit.Uwp.UI`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updated the parsing logic in `AspectRatio.ConvertToAspectRatio(string)` to be consistent with other parsing APIs.
The parsing is now done using `CultureInfo.InvariantCulture`, which fixes the crash reported in the linked issue.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] New component
  - [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [X] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [X] If control, added to Visual Studio Design project
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
