### PR TITLE
ListDetailsView unfocus content on SelectedIndex changed.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusItemList()
         {
-            if (GetTemplateChild("PartMainList") is Control list)
+            if (GetTemplateChild(PartMainList) is Control list)
             {
                 list.Focus(FocusState.Programmatic);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
             UpdateView(true);
+            SetFocus(ViewState);
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView_UI.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView_UI.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Markup;
 
 namespace UnitTests.UWP.UI.Controls
@@ -52,23 +53,22 @@ namespace UnitTests.UWP.UI.Controls
                 
                 await SetTestContentAsync(listDetailsView);
 
-                await Task.Delay(1000);
-
                 var firsttb = listDetailsView.FindDescendant<TextBox>();
 
-                firsttb.Focus(FocusState.Programmatic);
+                await App.DispatcherQueue.EnqueueAsync(() => firsttb.Focus(FocusState.Programmatic));
 
-                await Task.Delay(1000);
+                Assert.AreEqual(firsttb, FocusManager.GetFocusedElement(), "TextBox didn't get focus");
 
-                var firstLostFocus = false;
+                var tcs = new TaskCompletionSource<bool>();
 
-                firsttb.LostFocus += (s, e) => firstLostFocus = true;
+                firsttb.LostFocus += (s, e) => tcs.SetResult(true);
 
                 listDetailsView.SelectedIndex = -1;
 
-                await Task.Delay(1000);
+                await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
-                Assert.IsTrue(firstLostFocus, "TextBox in the first item should have lost focus.");
+                Assert.IsTrue(tcs.Task.IsCompleted);
+                Assert.IsTrue(tcs.Task.Result, "TextBox in the first item should have lost focus.");
             });
         }
 
@@ -90,23 +90,22 @@ namespace UnitTests.UWP.UI.Controls
 
                 await SetTestContentAsync(listDetailsView);
 
-                await Task.Delay(1000);
-
                 var firsttb = listDetailsView.FindDescendant<TextBox>();
 
-                firsttb.Focus(FocusState.Programmatic);
+                await App.DispatcherQueue.EnqueueAsync(() => firsttb.Focus(FocusState.Programmatic));
 
-                await Task.Delay(1000);
+                Assert.AreEqual(firsttb, FocusManager.GetFocusedElement(), "TextBox didn't get focus");
 
-                var firstLostFocus = false;
+                var tcs = new TaskCompletionSource<bool>();
 
-                firsttb.LostFocus += (s, e) => firstLostFocus = true;
+                firsttb.LostFocus += (s, e) => tcs.SetResult(true);
 
                 listDetailsView.SelectedIndex = 1;
 
-                await Task.Delay(1000);
+                await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
-                Assert.IsTrue(firstLostFocus, "TextBox in the first item should have lost focus.");
+                Assert.IsTrue(tcs.Task.IsCompleted);
+                Assert.IsTrue(tcs.Task.Result, "TextBox in the first item should have lost focus.");
             });
         }
     }

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView_UI.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_ListDetailsView_UI.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UnitTests.UWP.UI.Controls
+{
+    [TestClass]
+    public class Test_ListDetailsView_UI : VisualUITestBase
+    {
+        private const string SampleXaml = @"<controls:ListDetailsView
+                                                    xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+                                                    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+                                                    xmlns:controls=""using:Microsoft.Toolkit.Uwp.UI.Controls""
+                                                    NoSelectionContent=""No item selected"" >
+                                                    <controls:ListDetailsView.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text=""Item"" />
+                                                        </DataTemplate>
+                                                    </controls:ListDetailsView.ItemTemplate>
+                                                    <controls:ListDetailsView.DetailsTemplate>
+                                                        <DataTemplate>
+                                                            <TextBox Text=""{Binding}"" />
+                                                        </DataTemplate>
+                                                    </controls:ListDetailsView.DetailsTemplate>
+                                                 </controls:ListDetailsView>";
+
+        [TestCategory("ListDetailsView")]
+        [TestMethod]
+        public async Task Test_LoseFocusOnNoSelection()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var listDetailsView = XamlReader.Load(SampleXaml) as ListDetailsView;
+
+                listDetailsView.ItemsSource = new ObservableCollection<string>
+                {
+                     "First",
+                };
+
+                listDetailsView.SelectedIndex = 0;
+                
+                await SetTestContentAsync(listDetailsView);
+
+                await Task.Delay(1000);
+
+                var firsttb = listDetailsView.FindDescendant<TextBox>();
+
+                firsttb.Focus(FocusState.Programmatic);
+
+                await Task.Delay(1000);
+
+                var firstLostFocus = false;
+
+                firsttb.LostFocus += (s, e) => firstLostFocus = true;
+
+                listDetailsView.SelectedIndex = -1;
+
+                await Task.Delay(1000);
+
+                Assert.IsTrue(firstLostFocus, "TextBox in the first item should have lost focus.");
+            });
+        }
+
+        [TestCategory("ListDetailsView")]
+        [TestMethod]
+        public async Task Test_LoseFocusOnSelectOther()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var listDetailsView = XamlReader.Load(SampleXaml) as ListDetailsView;
+
+                listDetailsView.ItemsSource = new ObservableCollection<string>
+                {
+                     "First",
+                     "Second",
+                };
+
+                listDetailsView.SelectedIndex = 0;
+
+                await SetTestContentAsync(listDetailsView);
+
+                await Task.Delay(1000);
+
+                var firsttb = listDetailsView.FindDescendant<TextBox>();
+
+                firsttb.Focus(FocusState.Programmatic);
+
+                await Task.Delay(1000);
+
+                var firstLostFocus = false;
+
+                firsttb.LostFocus += (s, e) => firstLostFocus = true;
+
+                listDetailsView.SelectedIndex = 1;
+
+                await Task.Delay(1000);
+
+                Assert.IsTrue(firstLostFocus, "TextBox in the first item should have lost focus.");
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -237,6 +237,7 @@
     <Compile Include="UI\Controls\Test_ConstrainedBox.Multiple.cs" />
     <Compile Include="UI\Controls\Test_ConstrainedBox.Combined.cs" />
     <Compile Include="UI\Controls\Test_ImageEx.cs" />
+    <Compile Include="UI\Controls\Test_ListDetailsView_UI.cs" />
     <Compile Include="UI\Controls\Test_RadialGauge.cs" />
     <Compile Include="UI\Controls\Test_RichSuggestBox.cs" />
     <Compile Include="UI\Controls\Test_TextToolbar_Localization.cs" />


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4244 Also un-focuses content when SelectedIndex is changed.

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: "## Fixes #1234") which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

Makes sure that the details of the list details view is get un-selected when the SelectedIndex is updated directly.

> Note: This does not completely fix #3546, which would need to unfocus the details when the user clicks another item in the list. See #4222 

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
