### PR TITLE
Add property TextAlignment in DataGridTextColumn to support align the text in rows to right

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridTextColumn.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridTextColumn.cs
@@ -26,12 +26,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private const string DATAGRIDTEXTCOLUMN_fontStyleName = "FontStyle";
         private const string DATAGRIDTEXTCOLUMN_fontWeightName = "FontWeight";
         private const string DATAGRIDTEXTCOLUMN_foregroundName = "Foreground";
+        private const string DATAGRIDTEXTCOLUMN_textAlignmentName = "TextAlignment";
         private const double DATAGRIDTEXTCOLUMN_leftMargin = 12.0;
         private const double DATAGRIDTEXTCOLUMN_rightMargin = 12.0;
 
         private double? _fontSize;
         private FontStyle? _fontStyle;
         private FontWeight? _fontWeight;
+        private TextAlignment? _textAlignment;
         private Brush _foreground;
 
         /// <summary>
@@ -130,6 +132,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the text alignment of the column cells.
+        /// </summary>
+        public TextAlignment TextAlignment
+        {
+            get
+            {
+                return _textAlignment ?? TextAlignment.Left;
+            }
+
+            set
+            {
+                if (_textAlignment != value)
+                {
+                    _textAlignment = value;
+                    NotifyPropertyChanged(DATAGRIDTEXTCOLUMN_textAlignmentName);
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a brush that describes the foreground of the column cells.
         /// </summary>
         public Brush Foreground
@@ -196,6 +218,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 textBox.FontWeight = _fontWeight.Value;
             }
 
+            if (_textAlignment.HasValue)
+            {
+                textBox.TextAlignment = _textAlignment.Value;
+            }
+
             RefreshForeground(textBox, (cell != null & cell.OwningRow != null) ? cell.OwningRow.ComputedForeground : null);
 
             if (this.Binding != null)
@@ -235,6 +262,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (_fontWeight.HasValue)
             {
                 textBlockElement.FontWeight = _fontWeight.Value;
+            }
+
+            if (_textAlignment.HasValue)
+            {
+                textBlockElement.TextAlignment = _textAlignment.Value;
             }
 
             RefreshForeground(textBlockElement, (cell != null & cell.OwningRow != null) ? cell.OwningRow.ComputedForeground : null);
@@ -313,6 +345,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     textBlock.FontWeight = this.FontWeight;
                 }
+                else if (propertyName == DATAGRIDTEXTCOLUMN_textAlignmentName)
+                {
+                    textBlock.TextAlignment = this.TextAlignment;
+                }
                 else if (propertyName == DATAGRIDTEXTCOLUMN_foregroundName)
                 {
                     RefreshForeground(textBlock, computedRowForeground);
@@ -327,6 +363,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     SetTextFontSize(textBlock, TextBlock.FontSizeProperty);
                     textBlock.FontStyle = this.FontStyle;
                     textBlock.FontWeight = this.FontWeight;
+                    textBlock.TextAlignment = this.TextAlignment;
                     RefreshForeground(textBlock, computedRowForeground);
                 }
 
@@ -349,6 +386,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 textBox.FontWeight = this.FontWeight;
             }
+            else if (propertyName == DATAGRIDTEXTCOLUMN_textAlignmentName)
+            {
+                textBox.TextAlignment = this.TextAlignment;
+            }
             else if (propertyName == DATAGRIDTEXTCOLUMN_foregroundName)
             {
                 RefreshForeground(textBox, computedRowForeground);
@@ -363,6 +404,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SetTextFontSize(textBox, TextBox.FontSizeProperty);
                 textBox.FontStyle = this.FontStyle;
                 textBox.FontWeight = this.FontWeight;
+                textBox.TextAlignment = this.TextAlignment;
                 RefreshForeground(textBox, computedRowForeground);
             }
         }


### PR DESCRIPTION
## Fixes

Fixes #4276

I add optional property named TextAlignment in the class DataGridTextColumn.

## PR Type

Feature

## What is the current behavior?

Currently, I cannot align the text in DataGridTextColumn to right.

## What is the new behavior?

With the new optional property name TextAlignment we can align the text in rows.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [x] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

## Other information

Here is the result after I implemented TextAlignment
![image](https://user-images.githubusercontent.com/8206726/134756480-49b8073f-1c76-4be0-9657-082c1c1f0cdd.png)

