### PR TITLE
Fix MVVM Toolkit LINQ expression issues on .NET Framework

### DIFF
--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableValidator.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableValidator.cs
@@ -488,6 +488,20 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
             // Fallback method to create the delegate with a compiled LINQ expression
             static Action<object> GetValidationActionFallback(Type type)
             {
+                // Get the collection of all properties to validate
+                PropertyInfo[] validatableProperties = (
+                    from property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    where property.GetIndexParameters().Length == 0 &&
+                          property.GetCustomAttributes<ValidationAttribute>(true).Any() &&
+                          property.GetMethod is not null
+                    select property).ToArray();
+
+                // Short path if there are no properties to validate
+                if (validatableProperties.Length == 0)
+                {
+                    return static _ => { };
+                }
+
                 // MyViewModel inst0 = (MyViewModel)arg0;
                 ParameterExpression arg0 = Expression.Parameter(typeof(object));
                 UnaryExpression inst0 = Expression.Convert(arg0, type);
@@ -513,14 +527,10 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
                 // ObservableValidator externally, but that is fine because IL doesn't really have
                 // a concept of member visibility, that's purely a C# build-time feature.
                 BlockExpression body = Expression.Block(
-                    from property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                    where property.GetIndexParameters().Length == 0 &&
-                          property.GetCustomAttributes<ValidationAttribute>(true).Any()
-                    let getter = property.GetMethod
-                    where getter is not null
+                    from property in validatableProperties
                     select Expression.Call(inst0, validateMethod, new Expression[]
                     {
-                        Expression.Convert(Expression.Call(inst0, getter), typeof(object)),
+                        Expression.Convert(Expression.Call(inst0, property.GetMethod), typeof(object)),
                         Expression.Constant(property.Name)
                     }));
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4272

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
There are a couple of scenarios currently where the MVVM Toolkit crashes on .NET Framework:
- LINQ expression fallback path for `ObservableValidator.ValidateAllProperties` on a model with no validatable properties
- LINQ expression fallback path for `IMessengerExtensions.RegisterAll` on a recipient with no declared handlers

This is due to `Expression.Block` throwing when receiving an empty collection as input on .NET Framework.
It works fine from .NET Core 2.1 and onwards.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Added an explicit check and short path to skip the LINQ expression calls entirely if no targets are detected.
Both scenarios work correctly now.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [X] New component
  - [X] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [X] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [X] If control, added to Visual Studio Design project
- [X] Sample in sample app has been added / updated (for bug fixes / features)
  - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
