### PR TITLE
Fixed the debounce extension in order to update to the last action pa…

### DIFF
--- a/Microsoft.Toolkit.Uwp/Extensions/DispatcherQueueTimerExtensions.cs
+++ b/Microsoft.Toolkit.Uwp/Extensions/DispatcherQueueTimerExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 timer.Tick += Timer_Tick;
 
                 // Store/Update function
-                _debounceInstances.AddOrUpdate(timer, action, (k, v) => v);
+                _debounceInstances.AddOrUpdate(timer, action, (k, v) => action);
             }
 
             // Start the timer to keep track of the last call here.


### PR DESCRIPTION
## Fixes #4293

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

The debounce extension was incorrectly updating the action in the ConcurrentList.

According to documentation the value passed in the `updateValueFactory` function, of the `AddOrUpdate` method, is the current value in the dictionary.

https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.addorupdate?view=net-5.0

![image](https://user-images.githubusercontent.com/29243277/135733394-f7c4d682-9c24-45cd-af4d-69721a7c6383.png)

Therefore the current behavior is maintaining the old action and not updating with the new passed action.

```csharp
_debounceInstances.AddOrUpdate(timer, action, (k, v) => v);
```

## What is the new behavior?

Changed so that the action in the `_ debounceInstances` Dictionary is updated with the latest version.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes

## Other information

PS: The debuonce extension is referenced in the `CanvasPathGeometryPage` class (although this changes does not seem to break it).
