### PR TITLE
Add period to end of exception messages in Guard class

### DIFF
--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.Collection.Generic.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.Collection.Generic.ThrowHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotEmptyWithSpan<T>(string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(Span<T>).ToTypeString()}) must not be empty", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(Span<T>).ToTypeString()}) must not be empty.", name);
             }
 
             /// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotEmptyWithReadOnlySpan<T>(string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(ReadOnlySpan<T>).ToTypeString()}) must not be empty", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(ReadOnlySpan<T>).ToTypeString()}) must not be empty.", name);
             }
 
             /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotEmpty<T>(string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be empty", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be empty.", name);
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.Comparable.Generic.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.Comparable.Generic.ThrowHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsDefault<T>(T value, string name)
                 where T : struct
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be the default value {AssertString(default(T))}, was {AssertString(value)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be the default value {AssertString(default(T))}, was {AssertString(value)}.", name);
             }
 
             /// <summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsNotDefault<T>(string name)
                 where T : struct
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be the default value {AssertString(default(T))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be the default value {AssertString(default(T))}.", name);
             }
 
             /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsEqualTo<T>(T value, T target, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be equal to {AssertString(target)}, was {AssertString(value)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be equal to {AssertString(target)}, was {AssertString(value)}.", name);
             }
 
             /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotEqualTo<T>(T value, T target, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be equal to {AssertString(target)}, was {AssertString(value)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be equal to {AssertString(target)}, was {AssertString(value)}.", name);
             }
 
             /// <summary>
@@ -67,7 +67,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForBitwiseEqualTo<T>(T value, T target, string name)
                 where T : unmanaged
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) is not a bitwise match, was <{value.ToHexString()}> instead of <{target.ToHexString()}>", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) is not a bitwise match, was <{value.ToHexString()}> instead of <{target.ToHexString()}>.", name);
             }
 
             /// <summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsLessThan<T>(T value, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be less than {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be less than {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -87,7 +87,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo<T>(T value, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be less than or equal to {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be less than or equal to {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -97,7 +97,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsGreaterThan<T>(T value, T minimum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be greater than {AssertString(minimum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be greater than {AssertString(minimum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -107,7 +107,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo<T>(T value, T minimum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be greater than or equal to {AssertString(minimum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be greater than or equal to {AssertString(minimum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -117,7 +117,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsInRange<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be in the range given by {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be in the range given by {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsNotInRange<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be in the range given by {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be in the range given by {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -137,7 +137,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsBetween<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be between {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be between {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -147,7 +147,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsNotBetween<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be between {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be between {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be between or equal to {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be between or equal to {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
 
             /// <summary>
@@ -167,7 +167,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo<T>(T value, T minimum, T maximum, string name)
             {
-                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be between or equal to {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}");
+                throw new ArgumentOutOfRangeException(name, value!, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be between or equal to {AssertString(minimum)} and {AssertString(maximum)}, was {AssertString(value)}.");
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.Comparable.Numeric.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.Comparable.Numeric.ThrowHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCloseTo(int value, int target, uint delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(int).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((double)((long)value - target)))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(int).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((double)((long)value - target)))}.", name);
             }
 
             /// <summary>
@@ -32,7 +32,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCloseTo(int value, int target, uint delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(int).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((double)((long)value - target)))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(int).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((double)((long)value - target)))}.", name);
             }
 
             /// <summary>
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCloseTo(long value, long target, ulong delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(long).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((decimal)value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(long).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((decimal)value - target))}.", name);
             }
 
             /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCloseTo(long value, long target, ulong delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(long).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((decimal)value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(long).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs((decimal)value - target))}.", name);
             }
 
             /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCloseTo(float value, float target, float delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(float).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(float).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
 
             /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCloseTo(float value, float target, float delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(float).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(float).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
 
             /// <summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCloseTo(double value, double target, double delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(double).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(double).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
 
             /// <summary>
@@ -86,7 +86,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCloseTo(double value, double target, double delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(double).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(double).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
 
             /// <summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCloseTo(nint value, nint target, nuint delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(nint).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(nint).ToTypeString()}) must be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
 
             /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCloseTo(nint value, nint target, nuint delta, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(nint).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(nint).ToTypeString()}) must not be within a distance of {AssertString(delta)} from {AssertString(target)}, was {AssertString(value)} and had a distance of {AssertString(Math.Abs(value - target))}.", name);
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.IO.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.IO.ThrowHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForCanRead(Stream stream, string name)
             {
-                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support reading", name);
+                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support reading.", name);
             }
 
             /// <summary>
@@ -33,7 +33,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForCanWrite(Stream stream, string name)
             {
-                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support writing", name);
+                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support writing.", name);
             }
 
             /// <summary>
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForCanSeek(Stream stream, string name)
             {
-                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support seeking", name);
+                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) doesn't support seeking.", name);
             }
 
             /// <summary>
@@ -51,7 +51,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsAtStartPosition(Stream stream, string name)
             {
-                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) must be at position {AssertString(0)}, was at {AssertString(stream.Position)}", name);
+                throw new ArgumentException($"Stream {AssertString(name)} ({stream.GetType().ToTypeString()}) must be at position {AssertString(0)}, was at {AssertString(stream.Position)}.", name);
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.String.ThrowHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNullOrEmpty(string? text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be null or empty, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be null or empty, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -38,10 +38,10 @@ namespace Microsoft.Toolkit.Diagnostics
                 {
                     if (text is null)
                     {
-                        return new ArgumentNullException(name, $"Parameter {AssertString(name)} (string) must not be null or empty, was null");
+                        return new ArgumentNullException(name, $"Parameter {AssertString(name)} (string) must not be null or empty, was null.");
                     }
 
-                    return new ArgumentException($"Parameter {AssertString(name)} (string) must not be null or empty, was empty", name);
+                    return new ArgumentException($"Parameter {AssertString(name)} (string) must not be null or empty, was empty.", name);
                 }
 
                 throw GetException(text, name);
@@ -53,7 +53,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNullOrWhiteSpace(string? text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be null or whitespace, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be null or whitespace, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -67,10 +67,10 @@ namespace Microsoft.Toolkit.Diagnostics
                 {
                     if (text is null)
                     {
-                        return new ArgumentNullException(name, $"Parameter {AssertString(name)} (string) must not be null or whitespace, was null");
+                        return new ArgumentNullException(name, $"Parameter {AssertString(name)} (string) must not be null or whitespace, was null.");
                     }
 
-                    return new ArgumentException($"Parameter {AssertString(name)} (string) must not be null or whitespace, was whitespace", name);
+                    return new ArgumentException($"Parameter {AssertString(name)} (string) must not be null or whitespace, was whitespace.", name);
                 }
 
                 throw GetException(text, name);
@@ -82,7 +82,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsEmpty(string text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be empty, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be empty, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -91,7 +91,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotEmpty(string text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not be empty", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not be empty.", name);
             }
 
             /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsWhiteSpace(string text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be whitespace, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must be whitespace, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotWhiteSpace(string text, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not be whitespace, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not be whitespace, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -118,7 +118,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeEqualTo(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size equal to {size}, had a size of {text.Length} and was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size equal to {size}, had a size of {text.Length} and was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeNotEqualTo(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not have a size equal to {size}, was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must not have a size equal to {size}, was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -136,7 +136,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeGreaterThan(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size over {size}, had a size of {text.Length} and was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size over {size}, had a size of {text.Length} and was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -145,7 +145,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size of at least {size}, had a size of {text.Length} and was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size of at least {size}, had a size of {text.Length} and was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -154,7 +154,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeLessThan(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size less than {size}, had a size of {text.Length} and was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size less than {size}, had a size of {text.Length} and was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -163,7 +163,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(string text, int size, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size less than or equal to {size}, had a size of {text.Length} and was {AssertString(text)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} (string) must have a size less than or equal to {size}, had a size of {text.Length} and was {AssertString(text)}.", name);
             }
 
             /// <summary>
@@ -172,7 +172,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeEqualTo(string source, string destination, string name)
             {
-                throw new ArgumentException($"The source {AssertString(name)} (string) must have a size equal to {AssertString(destination.Length)} (the destination), had a size of {AssertString(source.Length)}", name);
+                throw new ArgumentException($"The source {AssertString(name)} (string) must have a size equal to {AssertString(destination.Length)} (the destination), had a size of {AssertString(source.Length)}.", name);
             }
 
             /// <summary>
@@ -181,7 +181,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(string source, string destination, string name)
             {
-                throw new ArgumentException($"The source {AssertString(name)} (string) must have a size less than or equal to {AssertString(destination.Length)} (the destination), had a size of {AssertString(source.Length)}", name);
+                throw new ArgumentException($"The source {AssertString(name)} (string) must have a size less than or equal to {AssertString(destination.Length)} (the destination), had a size of {AssertString(source.Length)}.", name);
             }
 
             /// <summary>
@@ -190,7 +190,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsInRangeFor(int index, string text, string name)
             {
-                throw new ArgumentOutOfRangeException(name, index, $"Parameter {AssertString(name)} (int) must be in the range given by <0> and {AssertString(text.Length)} to be a valid index for the target string, was {AssertString(index)}");
+                throw new ArgumentOutOfRangeException(name, index, $"Parameter {AssertString(name)} (int) must be in the range given by <0> and {AssertString(text.Length)} to be a valid index for the target string, was {AssertString(index)}.");
             }
 
             /// <summary>
@@ -199,7 +199,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(int index, string text, string name)
             {
-                throw new ArgumentOutOfRangeException(name, index, $"Parameter {AssertString(name)} (int) must not be in the range given by <0> and {AssertString(text.Length)} to be an invalid index for the target string, was {AssertString(index)}");
+                throw new ArgumentOutOfRangeException(name, index, $"Parameter {AssertString(name)} (int) must not be in the range given by <0> and {AssertString(text.Length)} to be an invalid index for the target string, was {AssertString(index)}.");
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.Tasks.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.Tasks.ThrowHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCompleted(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be completed, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be completed, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -33,7 +33,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCompleted(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be completed, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be completed, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCompletedSuccessfully(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be completed successfully, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be completed successfully, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -51,7 +51,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCompletedSuccessfully(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be completed successfully, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be completed successfully, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -60,7 +60,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsFaulted(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be faulted, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be faulted, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotFaulted(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be faulted, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be faulted, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -78,7 +78,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsCanceled(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be canceled, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must be canceled, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -87,7 +87,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotCanceled(Task task, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be canceled, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not be canceled, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -96,7 +96,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasStatusEqualTo(Task task, TaskStatus status, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must have status {status}, had status {AssertString(task.Status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must have status {status}, had status {AssertString(task.Status)}.", name);
             }
 
             /// <summary>
@@ -105,7 +105,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForHasStatusNotEqualTo(Task task, TaskStatus status, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not have status {AssertString(status)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({task.GetType().ToTypeString()}) must not have status {AssertString(status)}.", name);
             }
         }
     }

--- a/Microsoft.Toolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
+++ b/Microsoft.Toolkit.Diagnostics/Internals/Guard.ThrowHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsNull<T>(T value, string name)
                 where T : class
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be null, was {AssertString(value)} ({value.GetType().ToTypeString()})", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be null, was {AssertString(value)} ({value.GetType().ToTypeString()}).", name);
             }
 
             /// <summary>
@@ -53,7 +53,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsNull<T>(T? value, string name)
                 where T : struct
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T?).ToTypeString()}) must be null, was {AssertString(value)} ({typeof(T).ToTypeString()})", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T?).ToTypeString()}) must be null, was {AssertString(value)} ({typeof(T).ToTypeString()}).", name);
             }
 
             /// <summary>
@@ -63,7 +63,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentNullExceptionForIsNotNull<T>(string name)
             {
-                throw new ArgumentNullException(name, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be not null)");
+                throw new ArgumentNullException(name, $"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be not null).");
             }
 
             /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsOfType<T>(object value, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be of type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be of type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotOfType<T>(object value, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must not be of type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must not be of type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -92,7 +92,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsOfType(object value, Type type, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be of type {type.ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be of type {type.ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -101,7 +101,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotOfType(object value, Type type, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must not be of type {type.ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must not be of type {type.ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsAssignableToType<T>(object value, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be assignable to type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be assignable to type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -121,7 +121,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotAssignableToType<T>(object value, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must not be assignable to type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must not be assignable to type {typeof(T).ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -130,7 +130,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsAssignableToType(object value, Type type, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be assignable to type {type.ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be assignable to type {type.ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -139,7 +139,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsNotAssignableToType(object value, Type type, string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must not be assignable to type {type.ToTypeString()}, was {value.GetType().ToTypeString()}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must not be assignable to type {type.ToTypeString()}, was {value.GetType().ToTypeString()}.", name);
             }
 
             /// <summary>
@@ -150,7 +150,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsReferenceEqualTo<T>(string name)
                 where T : class
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be the same instance as the target object", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must be the same instance as the target object.", name);
             }
 
             /// <summary>
@@ -161,7 +161,7 @@ namespace Microsoft.Toolkit.Diagnostics
             public static void ThrowArgumentExceptionForIsReferenceNotEqualTo<T>(string name)
                 where T : class
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be the same instance as the target object", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} ({typeof(T).ToTypeString()}) must not be the same instance as the target object.", name);
             }
 
             /// <summary>
@@ -170,7 +170,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsTrue(string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be true, was false", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be true, was false.", name);
             }
 
             /// <summary>
@@ -179,7 +179,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsTrue(string name, string message)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be true, was false: {AssertString(message)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be true, was false: {AssertString(message)}.", name);
             }
 
             /// <summary>
@@ -188,7 +188,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsFalse(string name)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be false, was true", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be false, was true.", name);
             }
 
             /// <summary>
@@ -197,7 +197,7 @@ namespace Microsoft.Toolkit.Diagnostics
             [DoesNotReturn]
             public static void ThrowArgumentExceptionForIsFalse(string name, string message)
             {
-                throw new ArgumentException($"Parameter {AssertString(name)} must be false, was true: {AssertString(message)}", name);
+                throw new ArgumentException($"Parameter {AssertString(name)} must be false, was true: {AssertString(message)}.", name);
             }
         }
     }


### PR DESCRIPTION
## Fixes #4351 

Added a period to the end of exception messages in the `Guard` class (from the `Microsoft.Toolkit.Diagnostics` package).

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

Exception messages produced by the `Guard` class from the `Microsoft.Toolkit.Diagnostics` package do not end in a period, which is inconsistent with the BCL, and doesn't follow [Best practices for exceptions](https://docs.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#use-grammatically-correct-error-messages).

## What is the new behavior?

Exception messages in the `Guard` class now have a period at the end of them.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
