### PR TITLE
Fix Radial Gauge ScaleTickBrush color assignment

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RadialGauge/RadialGauge.cs
@@ -680,7 +680,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 ClearBrush(_needleBrush, NeedleBrushProperty);
                 ClearBrush(_trailBrush, TrailBrushProperty);
                 ClearBrush(_scaleBrush, ScaleBrushProperty);
-                ClearBrush(_scaleBrush, ScaleTickBrushProperty);
+                ClearBrush(_scaleTickBrush, ScaleTickBrushProperty);
                 ClearBrush(_tickBrush, TickBrushProperty);
                 ClearBrush(_foreground, ForegroundProperty);
             }
@@ -690,7 +690,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 RestoreBrush(_needleBrush, NeedleBrushProperty);
                 RestoreBrush(_trailBrush, TrailBrushProperty);
                 RestoreBrush(_scaleBrush, ScaleBrushProperty);
-                RestoreBrush(_scaleBrush, ScaleTickBrushProperty);
+                RestoreBrush(_scaleTickBrush, ScaleTickBrushProperty);
                 RestoreBrush(_tickBrush, TickBrushProperty);
                 RestoreBrush(_foreground, ForegroundProperty);
             }


### PR DESCRIPTION
Due to a typo or a merge conflict, the ScaleTickBrush of the RadialGauge control currently gets the color of the ScaleBrush instead of its own.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The ScaleTickBrush property accidently gets its value from the ScaleBrush value in XAML or Resource Dictionary.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
The ScaleTickBrush gets its value from the corresponding XAML setting or Resource Dictionary.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ x] Tested code with current [supported SDKs](../#supported)
- [ x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
