### PR TITLE
Fix ColorPickerButton SelectedColor bug 

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/ColorPicker/ColorPickerButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/ColorPicker/ColorPickerButton.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="SelectedColor"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty SelectedColorProperty =
-            DependencyProperty.Register(nameof(SelectedColor), typeof(Color), typeof(ColorPickerButton), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(SelectedColor), typeof(Color), typeof(ColorPickerButton), new PropertyMetadata(null, new PropertyChangedCallback(SelectedColorChanged)));
 
 #pragma warning disable SA1306 // Field names should begin with lower-case letter
         //// Template Parts
@@ -139,6 +139,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (CheckeredBackgroundBorder != null)
             {
                 CheckeredBackgroundBorder.Loaded += this.CheckeredBackgroundBorder_Loaded;
+            }
+        }
+
+        private static void SelectedColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is ColorPickerButton instance && !(instance.ColorPicker is null))
+            {
+                instance.ColorPicker.Color = instance.SelectedColor;
             }
         }
 

--- a/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTest.cs
+++ b/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTest.cs
@@ -42,7 +42,7 @@ namespace UITests.Tests
             var redButton = new Button(FindElement.ById("SetRedButton"));
 
             Verify.IsNotNull(colorpicker);
-            Verify.IsNotNull(colorpicker);
+            Verify.IsNotNull(redButton);
 
             colorpicker.Click();
 

--- a/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTest.cs
+++ b/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTest.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Windows.Apps.Test.Foundation.Controls;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+
+#if USING_TAEF
+using WEX.Logging.Interop;
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+namespace UITests.Tests
+{
+    [TestClass]
+    public class ColorPickerButtonTest : UITestBase
+    {
+        [ClassInitialize]
+        [TestProperty("RunAs", "User")]
+        [TestProperty("Classification", "ScenarioTestSuite")]
+        [TestProperty("Platform", "Any")]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TestEnvironment.Initialize(testContext, WinUICsUWPSampleApp);
+        }
+
+        /// <summary>
+        /// This test validates the two way binding of the selected color. It verifies that
+        /// when the bound property changes this change is properly forwarded to the internal colorpicker.
+        /// See also issue #4367
+        /// </summary>
+        [TestMethod]
+        [TestPage("ColorPickerButtonTestPage")]
+        public void TwoWayTestMethod()
+        {
+            var colorpicker = new Button(FindElement.ById("TheColorPickerButton"));
+
+            var redButton = new Button(FindElement.ById("SetRedButton"));
+
+            Verify.IsNotNull(colorpicker);
+            Verify.IsNotNull(colorpicker);
+
+            colorpicker.Click();
+
+            Wait.ForIdle();
+            var colorInput = GetColorPickerInputField();
+
+            Verify.AreEqual("008000", colorInput.GetText());
+
+            // close the picker
+            colorpicker.Click();
+
+            Wait.ForIdle();
+
+            redButton.Click();
+
+            Wait.ForIdle();
+
+            colorpicker.Click();
+
+            var colorInput_new = GetColorPickerInputField();
+            Verify.AreEqual("FF0000", colorInput_new.GetText());
+        }
+
+        private static Edit GetColorPickerInputField()
+        {
+            var channelButton = new Button(FindElement.ByName("Channels"));
+            Verify.IsNotNull(channelButton);
+
+            Wait.ForIdle();
+
+            channelButton.Click();
+
+            Wait.ForIdle();
+
+            var colorInput = new Edit(FindElement.ByName("Hexadecimal Color Input"));
+            Verify.IsNotNull(colorInput);
+            return colorInput;
+        }
+    }
+}

--- a/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTestPage.xaml
+++ b/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTestPage.xaml
@@ -1,0 +1,13 @@
+<Page x:Class="UITests.App.Pages.ColorPickerButtonTestPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
+    <StackPanel>
+        <controls:ColorPickerButton x:Name="TheColorPickerButton" SelectedColor="{x:Bind TheColor, Mode=TwoWay}" />
+        <Button Name="SetRedButton" Click="Button_Click">Set color to red</Button>
+    </StackPanel>
+</Page>

--- a/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTestPage.xaml.cs
+++ b/UITests/UITests.Tests.Shared/Controls/ColorPickerButtonTestPage.xaml.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.App.Pages
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class ColorPickerButtonTestPage : Page, INotifyPropertyChanged
+    {
+        private Color _theColor = Colors.Green;
+
+        public Color TheColor
+        {
+            get => _theColor;
+            set
+            {
+                if (_theColor != value)
+                {
+                    _theColor = value;
+                    OnPropertyChanged(nameof(TheColor));
+                }
+            }
+        }
+
+        public ColorPickerButtonTestPage()
+        {
+            DataContext = this;
+            this.InitializeComponent();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            TheColor = Colors.Red;
+        }
+    }
+}


### PR DESCRIPTION


## Fixes #4367

<!-- Add a brief overview here of the feature/bug & fix. -->
Update internal ColorPicker Color when ColorPickerButton SelectedColor changes

## PR Type

What kind of change does this PR introduce?

Bugfix 

## What is the current behavior?

When ColorPickerButton.SelectedColor Property changes, the changed color is not the one in the colorpicker when the user clicks on the ColorPickerButton

## What is the new behavior?

SelectedColor gets propagated to the internal colorpicker to fix this bug.


## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

I am unfamiliar with all the testing infrastructure you have in place, so I just created little sample app for myself with the following two snippets. Should I add those somewhere? 

 ```xaml
        <StackPanel>
            <controls:ColorPickerButton SelectedColor="{x:Bind TheColor, Mode=TwoWay}" />
            <Button Click="Button_Click">Set color to red</Button>
        </StackPanel>
```

```cs
private Color _theColor = Colors.Green;
public Color TheColor
{
    get => _theColor;
    set
    {
        if (_theColor != value)
        {
            _theColor = value;
            OnPropertyChanged(nameof(TheColor));
        }
    }
}

public MainPage()
{
    DataContext = this;
    this.InitializeComponent();
}

public event PropertyChangedEventHandler PropertyChanged;

private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

private void Button_Click(object sender, RoutedEventArgs e)
{
    TheColor = Colors.Red;
}
```
<!-- Please add any other information that might be helpful to reviewers. -->
