### PR TITLE
Improved opacity support in Radial Gauge

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RadialGauge/RadialGauge.cs
@@ -642,6 +642,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     tick = radialGauge._compositor.CreateSpriteVisual();
                     tick.Size = new Vector2((float)radialGauge.TickWidth, (float)radialGauge.TickLength);
                     tick.Brush = radialGauge._compositor.CreateColorBrush(radialGauge.TickBrush.Color);
+                    tick.Opacity = (float)radialGauge.TickBrush.Opacity;
                     tick.Offset = new Vector3(100 - ((float)radialGauge.TickWidth / 2), 0.0f, 0);
                     tick.CenterPoint = new Vector3((float)radialGauge.TickWidth / 2, 100.0f, 0);
                     tick.RotationAngleInDegrees = (float)radialGauge.ValueToAngle(i);
@@ -654,6 +655,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     tick = radialGauge._compositor.CreateSpriteVisual();
                     tick.Size = new Vector2((float)radialGauge.ScaleTickWidth, (float)radialGauge.ScaleWidth);
                     tick.Brush = radialGauge._compositor.CreateColorBrush(radialGauge.ScaleTickBrush.Color);
+                    tick.Opacity = (float)radialGauge.ScaleTickBrush.Opacity;
                     tick.Offset = new Vector3(100 - ((float)radialGauge.ScaleTickWidth / 2), (float)radialGauge.ScalePadding, 0);
                     tick.CenterPoint = new Vector3((float)radialGauge.ScaleTickWidth / 2, 100 - (float)radialGauge.ScalePadding, 0);
                     tick.RotationAngleInDegrees = (float)radialGauge.ValueToAngle(i);
@@ -665,6 +667,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             radialGauge._needle = radialGauge._compositor.CreateSpriteVisual();
             radialGauge._needle.Size = new Vector2((float)radialGauge.NeedleWidth, (float)radialGauge.NeedleLength);
             radialGauge._needle.Brush = radialGauge._compositor.CreateColorBrush(radialGauge.NeedleBrush.Color);
+            radialGauge._needle.Opacity = (float)radialGauge.NeedleBrush.Opacity;
             radialGauge._needle.CenterPoint = new Vector3((float)radialGauge.NeedleWidth / 2, (float)radialGauge.NeedleLength, 0);
             radialGauge._needle.Offset = new Vector3(100 - ((float)radialGauge.NeedleWidth / 2), 100 - (float)radialGauge.NeedleLength, 0);
             radialGauge._root.Children.InsertAtTop(radialGauge._needle);


### PR DESCRIPTION
This change adds support for Opacity in the brushes for the Radial Gauge elements that are drawn with the Composition API: Ticks, ScaleTicks, and Needle.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
To support transparency, apply the Opacity of the resource Brush to the Composition Visuals.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Only the XAML elements (Scale, Trail, and the texts) currently support Opacity in their Brushes. Composition API elements (Ticks, ScaleTicks, and Needle) do not support transparency.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
All UI elements now react in a similar way to a resource Brush with Opacity.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [*] Tested code with current UWP and WinUI 3 versions.
- [*] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
