### PR TITLE
Fix app domain unloading issue on .NET Framework

### DIFF
--- a/Microsoft.Toolkit.Mvvm/Messaging/Internals/System/Gen2GcCallback.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Internals/System/Gen2GcCallback.cs
@@ -41,6 +41,16 @@ namespace System
         /// <param name="target">The target object to pass as argument to <paramref name="callback"/>.</param>
         public static void Register(Action<object> callback, object target)
         {
+#if NETSTANDARD2_0
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
+            {
+                // On .NET Framework using a GC callback causes issues with app domain unloading,
+                // so the callback is not registered if that runtime is detected and just ignored.
+                // Users on .NET Framework will have to manually trim the messenger, if they'd like.
+                return;
+            }
+#endif
+
             _ = new Gen2GcCallback(callback, target);
         }
 

--- a/Microsoft.Toolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Toolkit.Mvvm.Messaging
     /// The <see cref="WeakReferenceMessenger"/> type will automatically perform internal trimming when
     /// full GC collections are invoked, so calling <see cref="Cleanup"/> manually is not necessary to
     /// ensure that on average the internal data structures are as trimmed and compact as possible.
+    /// Note: this is not supported when running on .NET Framework, due to app domain unloading issues.
     /// </para>
     /// </remarks>
     public sealed class WeakReferenceMessenger : IMessenger


### PR DESCRIPTION
Port of https://github.com/CommunityToolkit/dotnet/commit/e2b336184f51fcd755f3151222ff948176ee954c.

Didn't really see any other commits already in https://github.com/CommunityToolkit/dotnet that would meet the hotfix bar for 7.1.2, so I think it's just this one hotfix we need on top of the other stuff that's already here on `main`, eg. the animation fix.

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

- https://github.com/CommunityToolkit/dotnet/issues/14
- https://github.com/CommunityToolkit/dotnet/issues/12

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

The app domain cannot be loaded on .NET Framework when using `WeakReferenceMessenger`.

## What is the new behavior?

Auto trimming is disabled when running on .NET Framework, which solves the issue.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes