### PR TITLE
Clip inner content from AttachedCardShadow using CompositionMaskBrush

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Shadows/AttachedShadowWin2DXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Shadows/AttachedShadowWin2DXaml.bind
@@ -37,7 +37,8 @@
                                     CornerRadius="32"
                                     Color="@[Color:Brush:Black]"
                                     Offset="@[Offset:Vector3:4,4]"
-                                    Opacity="@[Opacity:DoubleSlider:1.0:0.0-1.0]"/>
+                                    Opacity="@[Opacity:DoubleSlider:1.0:0.0-1.0]"
+                                    InnerContentClipMode="@[InnerContentClipMode:Enum:InnerContentClipMode.CompositionMaskBrush]"/>
         </ui:Effects.Shadow>
       </Rectangle>
       <!-- If you want to apply a shadow directly in your visual tree to an untemplated element

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Shadows/AttachedShadowWin2DXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Shadows/AttachedShadowWin2DXaml.bind
@@ -38,7 +38,7 @@
                                     Color="@[Color:Brush:Black]"
                                     Offset="@[Offset:Vector3:4,4]"
                                     Opacity="@[Opacity:DoubleSlider:1.0:0.0-1.0]"
-                                    InnerContentClipMode="@[InnerContentClipMode:Enum:InnerContentClipMode.CompositionMaskBrush]"/>
+                                    InnerContentClipMode="@[InnerContentClipMode:Enum:InnerContentClipMode.CompositionGeometricClip]"/>
         </ui:Effects.Shadow>
       </Rectangle>
       <!-- If you want to apply a shadow directly in your visual tree to an untemplated element

--- a/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
     public enum InnerContentClipMode
     {
         /// <summary>
+        /// Do not clip inner content.
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Use <see cref="Windows.UI.Composition.CompositionMaskBrush"/> to clip inner content.
         /// </summary>
         /// <remarks>

--- a/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Toolkit.Uwp.UI.Media
 {
     /// <summary>
-    /// The method that shadows deriving from <see cref="AttachedCardShadowBase"/> use when clipping their inner content.
+    /// The method that each instance of <see cref="AttachedCardShadow"/> uses when clipping its inner content.
     /// </summary>
     public enum InnerContentClipMode
     {

--- a/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Enums/InnerContentClipMode.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Toolkit.Uwp.UI.Media
+{
+    /// <summary>
+    /// The method that shadows deriving from <see cref="AttachedCardShadowBase"/> use when clipping their inner content.
+    /// </summary>
+    public enum InnerContentClipMode
+    {
+        /// <summary>
+        /// Use <see cref="Windows.UI.Composition.CompositionMaskBrush"/> to clip inner content.
+        /// </summary>
+        /// <remarks>
+        /// This mode has better performance than <see cref="CompositionGeometricClip"/>.
+        /// </remarks>
+        CompositionMaskBrush,
+
+        /// <summary>
+        /// Use <see cref="Windows.UI.Composition.CompositionGeometricClip"/> to clip inner content.
+        /// </summary>
+        /// <remarks>
+        /// Content clipped in this mode will have smoother corners than when using <see cref="CompositionMaskBrush"/>.
+        /// </remarks>
+        CompositionGeometricClip
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -114,8 +114,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
             {
                 base.OnPropertyChanged(context, property, oldValue, newValue);
             }
-
-            base.OnPropertyChanged(context, property, oldValue, newValue);
         }
 
         /// <inheritdoc/>

--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
             DependencyProperty.Register(
                 nameof(InnerContentClipMode),
                 typeof(InnerContentClipMode),
-                typeof(AttachedCardShadowBase),
+                typeof(AttachedCardShadow),
                 new PropertyMetadata(InnerContentClipMode.CompositionGeometricClip, OnDependencyPropertyChanged));
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -212,6 +212,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
                 return;
             }
 
+            // Create a rounded rectangle Visual with a thick outline and no fill, then use a VisualSurface of it as an opacity mask for the shadow.
+            // This will have the effect of clipping the inner content of the shadow, so that the casting element is not covered by the shadow,
+            // while the shadow is still rendered outside of the element. Similar to what takes place in GetVisualClip,
+            // except here we use a brush to mask content instead of a pure geometric clip.
             var shapeVisual = context.GetResource(OpacityMaskShapeVisualResourceKey) ??
                 context.AddResource(OpacityMaskShapeVisualResourceKey, context.Compositor.CreateShapeVisual());
 

--- a/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>True if the resource exists, false otherwise</returns>
         public bool TryGetResource<T>(string key, out T resource)
         {
-            if (_resources != null && _resources.TryGetValue(key, out var objResource) && objResource is T tResource)
+            if (_resources is not null && _resources.TryGetValue(key, out var objResource) && objResource is T tResource)
             {
                 resource = tResource;
                 return true;
@@ -234,7 +234,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>The resource that was removed, if any</returns>
         public T RemoveResource<T>(string key)
         {
-            if (_resources != null && _resources.TryGetValue(key, out var objResource))
+            if (_resources is not null && _resources.TryGetValue(key, out var objResource))
             {
                 _resources.Remove(key);
                 if (objResource is T resource)
@@ -255,7 +255,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public T RemoveAndDisposeResource<T>(string key)
             where T : IDisposable
         {
-            if (_resources != null && _resources.TryGetValue(key, out var objResource))
+            if (_resources is not null && _resources.TryGetValue(key, out var objResource))
             {
                 _resources.Remove(key);
                 if (objResource is T resource)
@@ -309,7 +309,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         public void ClearAndDisposeResources()
         {
-            if (_resources != null)
+            if (_resources is not null)
             {
                 foreach (var kvp in _resources)
                 {

--- a/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>The resource that was removed, if any</returns>
         public T RemoveResource<T>(string key)
         {
-            if (_resources.TryGetValue(key, out var objResource))
+            if (_resources != null && _resources.TryGetValue(key, out var objResource))
             {
                 _resources.Remove(key);
                 if (objResource is T resource)
@@ -255,7 +255,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public T RemoveAndDisposeResource<T>(string key)
             where T : IDisposable
         {
-            if (_resources.TryGetValue(key, out var objResource))
+            if (_resources != null && _resources.TryGetValue(key, out var objResource))
             {
                 _resources.Remove(key);
                 if (objResource is T resource)

--- a/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Shadows/AttachedShadowElementContext.cs
@@ -137,10 +137,13 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             Parent.OnElementContextUninitialized(this);
 
-            SpriteVisual.Shadow = null;
-            SpriteVisual.Dispose();
+            if (SpriteVisual != null)
+            {
+                SpriteVisual.Shadow = null;
+                SpriteVisual.Dispose();
+            }
 
-            Shadow.Dispose();
+            Shadow?.Dispose();
 
             ElementCompositionPreview.SetElementChildVisual(Element, null);
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4410

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

This PR adds the option to clip inner content from shadows using `CompositionMaskBrush`, which may improve performance over the default `CompositionGeometricClip` method.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Sample app changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`AttachedCardShadow` only clips its inner content using `CompositionGeometricClip`, which can have poor framerates when several shadows are on screen at a time.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
Added the option to clip inner shadow content using `CompositionMaskBrush`, which improves performance over `CompositionGeometricClip` when several shadows are on screen at a time, but looks slightly worse as the boundary of the inner clipped are lacks anti aliasing.

An `InnerContentClipMode` enum was added, as well as an `AttachedCardShadow.InnerContentClipMode` property, making it possible to choose between `CompositionGeometricClip` and `CompositionMaskBrush` clipping modes.

When `CompositionMaskBrush` is selected, a `CompositionMaskBrush` is created, with a `CompositionSurfaceBrush` rendering a hollow rounded rectangle set as its `Mask` and a `CompositionSurfaceBrush` rendering the `SpriteVisual` with the `DropShadow` set as its `Source`. Then an additional `SpriteVisual` is created which renders the `CompositionMaskBrush`.

The `CompositionMaskBrush` has slightly worse visuals than `CompositionGeometricClip`, as the corners of the inner clipped area lack anti aliasing. This is difficult to notice when the shadow has low opacity, but can stand out with high opacity shadows. For that reason, this PR keeps `CompositionGeometricClip` as the default method, while `CompositionMaskBrush` can be selected manually.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

<!-- ## Other information -->

<!-- Please add any other information that might be helpful to reviewers. -->