### PR TITLE
discard null clicked items

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.Command.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.Command.cs
@@ -9,34 +9,59 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.Toolkit.Uwp.UI
 {
     /// <summary>
-    /// Provides the Command attached dependency property for the <see cref="Windows.UI.Xaml.Controls.ListViewBase"/>
+    /// Provides the Command attached dependency property for the <see cref="ListViewBase"/>
     /// </summary>
     public static partial class ListViewExtensions
     {
         /// <summary>
-        /// Attached <see cref="DependencyProperty"/> for binding an <see cref="System.Windows.Input.ICommand"/> to handle ListViewBase Item interaction by means of <see cref="Windows.UI.Xaml.Controls.ListViewBase"/> ItemClick event. ListViewBase IsItemClickEnabled must be set to true.
+        /// Attached <see cref="DependencyProperty"/> for binding an <see cref="ICommand"/> to handle ListViewBase Item interaction by means of <see cref="ListViewBase"/> ItemClick event. ListViewBase IsItemClickEnabled must be set to true.
         /// </summary>
-        public static readonly DependencyProperty CommandProperty = DependencyProperty.RegisterAttached("Command", typeof(ICommand), typeof(ListViewExtensions), new PropertyMetadata(null, OnCommandPropertyChanged));
+        public static readonly DependencyProperty CommandProperty = DependencyProperty.RegisterAttached(
+            "Command",
+            typeof(ICommand),
+            typeof(ListViewExtensions),
+            new PropertyMetadata(null, OnCommandPropertyChanged));
+
+        /// <summary>
+        /// Attached <see cref="DependencyProperty"/> to discard the null clicked items returned by <see cref="ListViewBase.ItemClick"/>.
+        /// If we click on a <see cref="ListViewBase"/> item while the list is reordered, we may receive a <see cref="ListViewBase.ItemClick"/>
+        /// event with a null <see cref="ItemClickEventArgs.ClickedItem"/> even if there is no null item within the list.
+        /// Setting to true this property will prevent the associated command from being executed when the clicked item is null.
+        /// Default value is false.
+        /// </summary>
+        public static readonly DependencyProperty DiscardNullClickedItemsProperty = DependencyProperty.RegisterAttached(
+            "DiscardNullClickedItems",
+            typeof(bool),
+            typeof(ListViewExtensions),
+            new PropertyMetadata(false));
 
         /// <summary>
         /// Gets the <see cref="ICommand"/> associated with the specified <see cref="ListViewBase"/>
         /// </summary>
-        /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/> to get the associated <see cref="ICommand"/> from</param>
+        /// <param name="obj">The <see cref="ListViewBase"/> to get the associated <see cref="ICommand"/> from</param>
         /// <returns>The <see cref="ICommand"/> associated with the <see cref="ListViewBase"/></returns>
-        public static ICommand GetCommand(ListViewBase obj)
-        {
-            return (ICommand)obj.GetValue(CommandProperty);
-        }
+        public static ICommand GetCommand(ListViewBase obj) => (ICommand)obj.GetValue(CommandProperty);
 
         /// <summary>
         /// Sets the <see cref="ICommand"/> associated with the specified <see cref="ListViewBase"/>
         /// </summary>
-        /// <param name="obj">The <see cref="Windows.UI.Xaml.Controls.ListViewBase"/> to associate the <see cref="ICommand"/> with</param>
+        /// <param name="obj">The <see cref="ListViewBase"/> to associate the <see cref="ICommand"/> with</param>
         /// <param name="value">The <see cref="ICommand"/> for binding to the <see cref="ListViewBase"/></param>
-        public static void SetCommand(ListViewBase obj, ICommand value)
-        {
-            obj.SetValue(CommandProperty, value);
-        }
+        public static void SetCommand(ListViewBase obj, ICommand value) => obj.SetValue(CommandProperty, value);
+
+        /// <summary>
+        /// Gets the <see cref="DiscardNullClickedItemsProperty"/> value associated with the specified <see cref="ListViewBase"/>
+        /// </summary>
+        /// <param name="obj">The <see cref="ListViewBase"/> to get the associated <see cref="DiscardNullClickedItemsProperty"/> from</param>
+        /// <returns>The <see cref="DiscardNullClickedItemsProperty"/> value associated with the <see cref="ListViewBase"/></returns>
+        public static bool GetDiscardNullClickedItems(ListViewBase obj) => (bool)obj.GetValue(DiscardNullClickedItemsProperty);
+
+        /// <summary>
+        /// Sets the <see cref="DiscardNullClickedItemsProperty"/> value associated with the specified <see cref="ListViewBase"/>
+        /// </summary>
+        /// <param name="obj">The <see cref="ListViewBase"/> to associate the <see cref="ICommand"/> with</param>
+        /// <param name="value">True to discard null clicked items.</param>
+        public static void SetDiscardNullClickedItems(ListViewBase obj, bool value) => obj.SetValue(DiscardNullClickedItemsProperty, value);
 
         private static void OnCommandPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
         {
@@ -47,14 +72,12 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return;
             }
 
-            var oldCommand = args.OldValue as ICommand;
-            if (oldCommand != null)
+            if (args.OldValue is ICommand oldCommand)
             {
                 listViewBase.ItemClick -= OnListViewBaseItemClick;
             }
 
-            var newCommand = args.NewValue as ICommand;
-            if (newCommand != null)
+            if (args.NewValue is ICommand newCommand)
             {
                 listViewBase.ItemClick += OnListViewBaseItemClick;
             }
@@ -63,13 +86,18 @@ namespace Microsoft.Toolkit.Uwp.UI
         private static void OnListViewBaseItemClick(object sender, ItemClickEventArgs e)
         {
             var listViewBase = sender as ListViewBase;
-            var command = GetCommand(listViewBase);
-            if (listViewBase == null || command == null)
+            if (listViewBase == null)
             {
                 return;
             }
 
-            if (command.CanExecute(e.ClickedItem))
+            if (GetDiscardNullClickedItems(listViewBase) && e.ClickedItem == null)
+            {
+                return;
+            }
+
+            var command = GetCommand(listViewBase);
+            if (command?.CanExecute(e.ClickedItem) == true)
             {
                 command.Execute(e.ClickedItem);
             }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4453 4453

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix 

## What is the current behavior?
`ListViewBase.ItemClick` can be triggered with a null `ItemClickEventArgs.ClickedItem` even if it does not contain any null item.
The is a system XAML issue.

## What is the new behavior?
I'm adding a new `DiscardNullClickedItemsProperty` attached property to `ListviewExtensions`.
If this property is set to:
-  **True**: any `ListViewBase.ItemClick` event triggered with a null `ItemClickEventArgs.ClickedItem` will be discarded.
- **False**: The `ItemClickEventArgs.ClickedItem` vaklue is always provided to the attached `ICommand` (default value).

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

I've also updated a bit the code to shortened it and prevent a `NullReferenceException` in `OnListViewBaseItemClick`
