### PR TITLE
Fix linter issues with ReadMe

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -56,8 +56,6 @@ This project is supported by the [.NET Foundation](http://dotnetfoundation.org).
 
 ## 🏆 Contributors
 
-<a href="https://github.com/CommunityToolkit/WindowsCommunityToolkit/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=CommunityToolkit/WindowsCommunityToolkit" />
-</a>
+[![Toolkit Contributors](https://contrib.rocks/image?repo=CommunityToolkit/WindowsCommunityToolkit)](https://github.com/CommunityToolkit/WindowsCommunityToolkit/graphs/contributors)
 
 Made with [contrib.rocks](https://contrib.rocks).

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,7 +54,7 @@ For more information see the [.NET Foundation Code of Conduct](CODE_OF_CONDUCT.m
 
 This project is supported by the [.NET Foundation](http://dotnetfoundation.org).
 
-## Contributors
+## 🏆 Contributors
 
 <a href="https://github.com/CommunityToolkit/WindowsCommunityToolkit/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=CommunityToolkit/WindowsCommunityToolkit" />


### PR DESCRIPTION
## Contributes to #4068

- Use an emoji for Contributors' title
  Rest of the titles have emojis, why not this? So, I used Champion Cup (`🏆`) emoji.
- Don't use inline HTML in markdown
  The format to represent image with a link is supported by most markdown parsers: `[![alt-text](image-link)](info-link)`.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- ReadMe content changes (_refactor and fixes_)

## What is the current behavior?

My markdown linter reports issues with in-line HTML.

## What is the new behavior?

Made sure that we convert the in-line HTML to markdown format.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Contains **NO** breaking changes

## Other information

**Squash merge** if possible.
