### PR TITLE
fix: Simplify & improve DataGridColumn support in LostFocus + fix related initial cell selection bug

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Data/DataGridDataItem.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Data/DataGridDataItem.cs
@@ -152,6 +152,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.Data
         // You need to use DateTimeOffset to get proper binding to the CalendarDatePicker control, DateTime won't work.
         public DateTimeOffset First_ascent { get; set; }
 
+        public bool IsFavorite { get; set; }
+
         public string Ascents { get; set; }
 
         bool INotifyDataErrorInfo.HasErrors

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid/DataGridCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid/DataGridCode.bind
@@ -85,6 +85,7 @@
         <controls:DataGridTextColumn Header="Rank" Binding="{Binding Rank}" Tag="Rank" />
         <controls:DataGridComboBoxColumn Header="Mountain" Binding="{Binding Mountain}" Tag="Mountain" />
         <controls:DataGridTextColumn Header="Height (m)" Binding="{Binding Height_m}" Tag="Height_m" />
+        <controls:DataGridCheckBoxColumn Header="Favorite status" Binding="{Binding IsFavorite, Mode=TwoWay}" />
         <controls:DataGridTextColumn Header="Range" Binding="{Binding Range}" Tag="Range" />
         <controls:DataGridTextColumn Header="Parent Mountain" Binding="{Binding Parent_mountain}" Tag="Parent_mountain" />
         <controls:DataGridTemplateColumn Header="First Ascent" Tag="First_ascent">


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4374
<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Users reported that DataGrid wouldn't work well with some types of DataGridColumns after #4206. I was able to reproduce the broken behavior with DataGridComboBoxColumn. Additionally, DataGridCheckBoxColumn was reported as flickering as it required an unnatural number of invocations to simply edit the Checked state. With this PR, I do the following:

* Simplify and improve the work done in #4206 
* Fixes what appears to be a logic error involving when the DataGridCell VisualState for edit mode is updated, ensuring it should be done properly upon selection (#4374)
* Update sample app to include DataGridCheckBoxColumn 

## PR Type

What kind of change does this PR introduce?

Bugfix; Sample app changes; minor Refactoring

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Clicking on a bound DataGridCheckBoxColumn in DataGrid will require an additional invocation before entering "edit mode". This bug produced an undesirable flickering effect for DataGridCheckBoxColumn.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Only a single invocation (click, tap) is now required to enter edit mode. Additional invocations will be observed by the editing element itself rather than being ignored (that is, until the editing element loses focus)
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information
N/A
<!-- Please add any other information that might be helpful to reviewers. -->
