### PR TITLE
Added CultureInfo to StringFormatConverter

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Converters/StringFormatConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Converters/StringFormatConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using Windows.UI.Xaml.Data;
 
 namespace Microsoft.Toolkit.Uwp.UI.Converters
@@ -13,12 +14,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
     public class StringFormatConverter : IValueConverter
     {
         /// <summary>
+        /// Gets or sets the CultureInfo to make converter culture sensitive. The default value is <see cref="CultureInfo.CurrentCulture"/>
+        /// </summary>
+        public CultureInfo CultureInfo { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringFormatConverter"/> class.
+        /// </summary>
+        public StringFormatConverter()
+        {
+            CultureInfo = CultureInfo.CurrentCulture;
+        }
+
+        /// <summary>
         /// Return the formatted string version of the source object.
         /// </summary>
         /// <param name="value">Object to transform to string.</param>
         /// <param name="targetType">The type of the target property, as a type reference</param>
         /// <param name="parameter">An optional parameter to be used in the string.Format method.</param>
-        /// <param name="language">The language of the conversion (not used).</param>
+        /// <param name="language">The language of the conversion. If language is null or empty then <see cref="CultureInfo"/> will be used.</param>
         /// <returns>Formatted string.</returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
@@ -27,20 +41,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
                 return null;
             }
 
-            if (parameter == null)
+            string formatParameter = parameter as string;
+            if (formatParameter == null)
             {
                 return value;
             }
 
-            try
-            {
-                return string.Format((string)parameter, value);
-            }
-            catch
-            {
-            }
-
-            return value;
+            return FormatToString(value, formatParameter, GetCultureInfoOrDefault(language, () => GetDefaultCultureInfo()));
         }
 
         /// <summary>
@@ -54,6 +61,54 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException();
+        }
+
+        private object FormatToString(object value, string parameter, CultureInfo cultureInfo)
+        {
+            try
+            {
+                return string.Format(cultureInfo, parameter, value);
+            }
+            catch
+            {
+                return value;
+            }
+        }
+
+        private CultureInfo GetCultureInfoOrDefault(string language, Func<CultureInfo> getDefaultCultureInfo)
+        {
+            CultureInfo cultureInfo;
+            if (!TryGetCultureInfo(language, out cultureInfo))
+            {
+                cultureInfo = getDefaultCultureInfo();
+            }
+
+            return cultureInfo;
+        }
+
+        private bool TryGetCultureInfo(string language, out CultureInfo cultureInfo)
+        {
+            cultureInfo = null;
+            if (string.IsNullOrEmpty(language))
+            {
+                return false;
+            }
+
+            try
+            {
+                cultureInfo = CultureInfo.GetCultureInfo(language);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private CultureInfo GetDefaultCultureInfo()
+        {
+            return CultureInfo ?? CultureInfo.InvariantCulture;
         }
     }
 }


### PR DESCRIPTION
## Fixes #3243

Extended StringFormatConverter functionality to make it culture aware. 
> New property (CultureInfo) was added to the converter. 
> Added support for language argument in Convert method.

## PR Type

What kind of change does this PR introduce?

Bugfix
Refactoring (no functional changes, no api changes) 

## What is the current behavior?

Currently it is not possible to use StringFormatConverter and eg. format number to represent its value as amount in specyfic currency. 

## What is the new behavior?

With the change converter is aware about a CultureInfo and can use it to format the text according to given setup. By default converter defaults the CultureInfo propety to CultureInfo.CurrentCulture which guarantees backward compatibility. Once the Convert is executed first it checkes if the language is passed to the method. If it's there (not null or empty), converters selects related CultureInfo otherwise coverter will take the CultureInfo already set in the propety. If that propety would be null then converter will apply InvariantCulture however this might happen only when the Converter.CultureInfo would be explicitly defaulted to null. Finally converter passes selected CultureInfo into the striong.Format to run finnal formatting.

## PR Checklist

Please check if your PR fulfills the following requirements: 

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes

## Other information

