### PR TITLE
Add Evaluate() method to expression nodes

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/CompositionExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/CompositionExtensions.cs
@@ -263,5 +263,46 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 
             return expressionNode.ExpressionAnimation;
         }
+
+        internal static float EvaluateSubchannel(this ExpressionNode node, string subchannel) => (node, subchannel) switch
+        {
+            (Vector2Node n, "X") => n.Evaluate().X,
+            (Vector2Node n, "Y") => n.Evaluate().Y,
+
+            (Vector3Node n, "X") => n.Evaluate().X,
+            (Vector3Node n, "Y") => n.Evaluate().Y,
+            (Vector3Node n, "Z") => n.Evaluate().Z,
+
+            (Vector4Node n, "X") => n.Evaluate().X,
+            (Vector4Node n, "Y") => n.Evaluate().Y,
+            (Vector4Node n, "Z") => n.Evaluate().Z,
+            (Vector4Node n, "W") => n.Evaluate().W,
+
+            (Matrix3x2Node n, "Channel11") => n.Evaluate().M11,
+            (Matrix3x2Node n, "Channel12") => n.Evaluate().M12,
+            (Matrix3x2Node n, "Channel21") => n.Evaluate().M21,
+            (Matrix3x2Node n, "Channel22") => n.Evaluate().M22,
+            (Matrix3x2Node n, "Channel31") => n.Evaluate().M31,
+            (Matrix3x2Node n, "Channel32") => n.Evaluate().M32,
+
+            (Matrix4x4Node n, "Channel11") => n.Evaluate().M11,
+            (Matrix4x4Node n, "Channel12") => n.Evaluate().M12,
+            (Matrix4x4Node n, "Channel13") => n.Evaluate().M13,
+            (Matrix4x4Node n, "Channel14") => n.Evaluate().M14,
+            (Matrix4x4Node n, "Channel21") => n.Evaluate().M21,
+            (Matrix4x4Node n, "Channel22") => n.Evaluate().M22,
+            (Matrix4x4Node n, "Channel23") => n.Evaluate().M23,
+            (Matrix4x4Node n, "Channel24") => n.Evaluate().M24,
+            (Matrix4x4Node n, "Channel31") => n.Evaluate().M31,
+            (Matrix4x4Node n, "Channel32") => n.Evaluate().M32,
+            (Matrix4x4Node n, "Channel33") => n.Evaluate().M33,
+            (Matrix4x4Node n, "Channel34") => n.Evaluate().M34,
+            (Matrix4x4Node n, "Channel41") => n.Evaluate().M41,
+            (Matrix4x4Node n, "Channel42") => n.Evaluate().M42,
+            (Matrix4x4Node n, "Channel43") => n.Evaluate().M43,
+            (Matrix4x4Node n, "Channel44") => n.Evaluate().M44,
+
+            _ => 0
+        };
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/BooleanNode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/BooleanNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 {
     // Ignore warning: 'BooleanNode' defines operator == or operator != but does not override Object.Equals(object o) && Object.GetHashCode()
@@ -127,6 +129,69 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private bool _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public bool Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.Equals:
+                    return Equals(Children[0], Children[1]);
+                case ExpressionNodeType.NotEquals:
+                    return !Equals(Children[0], Children[1]);
+                case ExpressionNodeType.And:
+                    return (Children[0] as BooleanNode).Evaluate() && (Children[1] as BooleanNode).Evaluate();
+                case ExpressionNodeType.Or:
+                    return (Children[0] as BooleanNode).Evaluate() || (Children[1] as BooleanNode).Evaluate();
+                case ExpressionNodeType.LessThan:
+                    return (Children[0] as ScalarNode).Evaluate() < (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.LessThanEquals:
+                    return (Children[0] as ScalarNode).Evaluate() <= (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.GreaterThan:
+                    return (Children[0] as ScalarNode).Evaluate() > (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.GreaterThanEquals:
+                    return (Children[0] as ScalarNode).Evaluate() >= (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Not:
+                    return !(Children[0] as BooleanNode).Evaluate();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    switch (PropertyName)
+                    {
+                        default:
+                            reference.Properties.TryGetBoolean(PropertyName, out var referencedProperty);
+                            return referencedProperty;
+                    }
+
+                case ExpressionNodeType.Conditional:
+                    return
+                        (Children[0] as BooleanNode).Evaluate() ?
+                        (Children[1] as BooleanNode).Evaluate() :
+                        (Children[2] as BooleanNode).Evaluate();
+                default:
+                    throw new NotImplementedException();
+            }
+
+            bool Equals(ExpressionNode e1, ExpressionNode e2) => (e1, e2) switch
+                {
+                    (BooleanNode n1, BooleanNode n2) => n1.Evaluate() == n2.Evaluate(),
+                    (ScalarNode n1, ScalarNode n2) => n1.Evaluate() == n2.Evaluate(),
+                    (Vector2Node n1, Vector2Node n2) => n1.Evaluate() == n2.Evaluate(),
+                    (Vector3Node n1, Vector3Node n2) => n1.Evaluate() == n2.Evaluate(),
+                    (Vector4Node n1, Vector4Node n2) => n1.Evaluate() == n2.Evaluate(),
+                    (ColorNode n1, ColorNode n2) => n1.Evaluate() == n2.Evaluate(),
+                    (QuaternionNode n1, QuaternionNode n2) => n1.Evaluate() == n2.Evaluate(),
+                    (Matrix3x2Node n1, Matrix3x2Node n2) => n1.Evaluate() == n2.Evaluate(),
+                    (Matrix4x4Node n1, Matrix4x4Node n2) => n1.Evaluate() == n2.Evaluate(),
+                    _ => false
+                };
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Matrix3x2Node.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Matrix3x2Node.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
@@ -336,6 +337,59 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private Matrix3x2 _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public Matrix3x2 Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    reference.Properties.TryGetMatrix3x2(PropertyName, out var referencedProperty);
+                    return referencedProperty;
+                case ExpressionNodeType.Add:
+                    return
+                        (Children[0] as Matrix3x2Node).Evaluate() +
+                        (Children[1] as Matrix3x2Node).Evaluate();
+                case ExpressionNodeType.Subtract:
+                    return
+                        (Children[0] as Matrix3x2Node).Evaluate() -
+                        (Children[1] as Matrix3x2Node).Evaluate();
+                case ExpressionNodeType.Negate:
+                    return
+                        -(Children[0] as Matrix3x2Node).Evaluate();
+                case ExpressionNodeType.Multiply:
+                    return (Children[0], Children[1]) switch
+                    {
+                        (Matrix3x2Node v1, Matrix3x2Node v2) => v1.Evaluate() * v2.Evaluate(),
+                        (Matrix3x2Node v1, ScalarNode s2) => v1.Evaluate() * s2.Evaluate(),
+                        (ScalarNode s1, Matrix3x2Node v2) => v2.Evaluate() * s1.Evaluate(),
+                        _ => throw new NotImplementedException()
+                    };
+                case ExpressionNodeType.Conditional:
+                    return
+                        (Children[0] as BooleanNode).Evaluate() ?
+                        (Children[1] as Matrix3x2Node).Evaluate() :
+                        (Children[2] as Matrix3x2Node).Evaluate();
+                case ExpressionNodeType.Swizzle:
+                    return new Matrix3x2(
+                        Children[0].EvaluateSubchannel(Subchannels[0]),
+                        Children[0].EvaluateSubchannel(Subchannels[1]),
+                        Children[0].EvaluateSubchannel(Subchannels[2]),
+                        Children[0].EvaluateSubchannel(Subchannels[3]),
+                        Children[0].EvaluateSubchannel(Subchannels[4]),
+                        Children[0].EvaluateSubchannel(Subchannels[5]));
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Matrix4x4Node.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Matrix4x4Node.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Numerics;
+using Windows.UI.Composition;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 {
@@ -410,6 +412,79 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private Matrix4x4 _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public Matrix4x4 Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    return PropertyName switch
+                    {
+                        nameof(Visual.TransformMatrix) => (reference as Visual).TransformMatrix,
+                        _ => GetProperty()
+                    };
+
+                    Matrix4x4 GetProperty()
+                    {
+                        reference.Properties.TryGetMatrix4x4(PropertyName, out var value);
+                        return value;
+                    }
+
+                case ExpressionNodeType.Add:
+                    return
+                        (Children[0] as Matrix4x4Node).Evaluate() +
+                        (Children[1] as Matrix4x4Node).Evaluate();
+                case ExpressionNodeType.Subtract:
+                    return
+                        (Children[0] as Matrix4x4Node).Evaluate() -
+                        (Children[1] as Matrix4x4Node).Evaluate();
+                case ExpressionNodeType.Negate:
+                    return
+                        -(Children[0] as Matrix4x4Node).Evaluate();
+                case ExpressionNodeType.Multiply:
+                    return (Children[0], Children[1]) switch
+                    {
+                        (Matrix4x4Node v1, Matrix4x4Node v2) => v1.Evaluate() * v2.Evaluate(),
+                        (Matrix4x4Node v1, ScalarNode s2) => v1.Evaluate() * s2.Evaluate(),
+                        (ScalarNode s1, Matrix4x4Node v2) => v2.Evaluate() * s1.Evaluate(),
+                        _ => throw new NotImplementedException()
+                    };
+                case ExpressionNodeType.Conditional:
+                    return
+                        (Children[0] as BooleanNode).Evaluate() ?
+                        (Children[1] as Matrix4x4Node).Evaluate() :
+                        (Children[2] as Matrix4x4Node).Evaluate();
+                case ExpressionNodeType.Swizzle:
+                    return new Matrix4x4(
+                        Children[0].EvaluateSubchannel(Subchannels[0]),
+                        Children[0].EvaluateSubchannel(Subchannels[1]),
+                        Children[0].EvaluateSubchannel(Subchannels[2]),
+                        Children[0].EvaluateSubchannel(Subchannels[3]),
+                        Children[0].EvaluateSubchannel(Subchannels[4]),
+                        Children[0].EvaluateSubchannel(Subchannels[5]),
+                        Children[0].EvaluateSubchannel(Subchannels[6]),
+                        Children[0].EvaluateSubchannel(Subchannels[7]),
+                        Children[0].EvaluateSubchannel(Subchannels[8]),
+                        Children[0].EvaluateSubchannel(Subchannels[9]),
+                        Children[0].EvaluateSubchannel(Subchannels[10]),
+                        Children[0].EvaluateSubchannel(Subchannels[11]),
+                        Children[0].EvaluateSubchannel(Subchannels[12]),
+                        Children[0].EvaluateSubchannel(Subchannels[13]),
+                        Children[0].EvaluateSubchannel(Subchannels[14]),
+                        Children[0].EvaluateSubchannel(Subchannels[15]));
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ScalarNode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ScalarNode.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Numerics;
+using Windows.UI.Composition;
+
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 {
     // Ignore warning: 'ScalarNode' defines operator == or operator != but does not override Object.Equals(object o) && Object.GetHashCode()
@@ -258,6 +262,106 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private float _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public float Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    return PropertyName switch
+                    {
+                        nameof(Visual.Opacity) => (reference as Visual).Opacity,
+                        nameof(Visual.RotationAngle) => (reference as Visual).RotationAngle,
+                        nameof(InsetClip.BottomInset) => (reference as InsetClip).BottomInset,
+                        nameof(InsetClip.LeftInset) => (reference as InsetClip).LeftInset,
+                        nameof(InsetClip.RightInset) => (reference as InsetClip).RightInset,
+                        nameof(InsetClip.TopInset) => (reference as InsetClip).TopInset,
+                        _ => GetProperty()
+                    };
+
+                    float GetProperty()
+                    {
+                        reference.Properties.TryGetScalar(PropertyName, out var value);
+                        return value;
+                    }
+
+                case ExpressionNodeType.Negate:
+                    return -(Children[0] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Add:
+                    return (Children[0] as ScalarNode).Evaluate() + (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Subtract:
+                    return (Children[0] as ScalarNode).Evaluate() - (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Multiply:
+                    return (Children[0] as ScalarNode).Evaluate() * (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Divide:
+                    return (Children[0] as ScalarNode).Evaluate() / (Children[1] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Min:
+                    return MathF.Min((Children[0] as ScalarNode).Evaluate(), (Children[1] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Max:
+                    return MathF.Max((Children[0] as ScalarNode).Evaluate(), (Children[1] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Absolute:
+                    return MathF.Abs((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Sin:
+                    return MathF.Sin((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Cos:
+                    return MathF.Cos((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Asin:
+                    return MathF.Asin((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Acos:
+                    return MathF.Acos((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Atan:
+                    return MathF.Atan((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Log10:
+                    return MathF.Log10((Children[0] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Conditional:
+                    return (Children[0] as BooleanNode).Evaluate() ? (Children[1] as ScalarNode).Evaluate() : (Children[2] as ScalarNode).Evaluate();
+                case ExpressionNodeType.Distance:
+                    return Vector2.Distance((Children[0] as Vector2Node).Evaluate(), (Children[1] as Vector2Node).Evaluate());
+                case ExpressionNodeType.Lerp:
+                {
+                    var start = (Children[0] as ScalarNode).Evaluate();
+                    var end = (Children[1] as ScalarNode).Evaluate();
+                    var progress = (Children[2] as ScalarNode).Evaluate();
+                    return start + (progress * (end - start));
+                }
+
+                case ExpressionNodeType.Swizzle:
+                    return Children[0] switch
+                    {
+                        ScalarNode n => n.Evaluate(),
+                        Vector2Node n => Subchannels[0] switch
+                        {
+                            "X" => n.Evaluate().X,
+                            _ => n.Evaluate().Y,
+                        },
+                        Vector3Node n => Subchannels[0] switch
+                        {
+                            "X" => n.Evaluate().X,
+                            "Y" => n.Evaluate().Y,
+                            _ => n.Evaluate().Z,
+                        },
+                        Vector4Node n => Subchannels[0] switch
+                        {
+                            "X" => n.Evaluate().X,
+                            "Y" => n.Evaluate().Y,
+                            "Z" => n.Evaluate().Z,
+                            _ => n.Evaluate().W,
+                        },
+                        _ => throw new NotImplementedException()
+                    };
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Vector2Node.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Vector2Node.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Numerics;
+using Windows.UI.Composition;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 {
@@ -301,6 +303,70 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private Vector2 _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public Vector2 Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    return PropertyName switch
+                    {
+                        nameof(Visual.Size) => (reference as Visual).Size,
+                        nameof(Visual.AnchorPoint) => (reference as Visual).AnchorPoint,
+                        _ => GetProperty()
+                    };
+
+                    Vector2 GetProperty()
+                    {
+                        reference.Properties.TryGetVector2(PropertyName, out var value);
+                        return value;
+                    }
+
+                case ExpressionNodeType.Conditional:
+                    return
+                        (Children[0] as BooleanNode).Evaluate() ?
+                        (Children[1] as Vector2Node).Evaluate() :
+                        (Children[2] as Vector2Node).Evaluate();
+                case ExpressionNodeType.Add:
+                    return
+                        (Children[0] as Vector2Node).Evaluate() +
+                        (Children[1] as Vector2Node).Evaluate();
+                case ExpressionNodeType.Subtract:
+                    return
+                        (Children[0] as Vector2Node).Evaluate() -
+                        (Children[1] as Vector2Node).Evaluate();
+                case ExpressionNodeType.Negate:
+                    return
+                        -(Children[0] as Vector2Node).Evaluate();
+                case ExpressionNodeType.Multiply:
+                    return (Children[0], Children[1]) switch
+                    {
+                        (Vector2Node v1, Vector2Node v2) => v1.Evaluate() * v2.Evaluate(),
+                        (Vector2Node v1, ScalarNode s2) => v1.Evaluate() * s2.Evaluate(),
+                        (ScalarNode s1, Vector2Node v2) => s1.Evaluate() * v2.Evaluate(),
+                        _ => throw new NotImplementedException()
+                    };
+                case ExpressionNodeType.Divide:
+                    return
+                        (Children[0] as Vector2Node).Evaluate() /
+                        (Children[1] as Vector2Node).Evaluate();
+                case ExpressionNodeType.Vector2:
+                    return new Vector2((Children[0] as ScalarNode).Evaluate(), (Children[1] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Swizzle:
+                    return new Vector2(Children[0].EvaluateSubchannel(Subchannels[0]), Children[0].EvaluateSubchannel(Subchannels[1]));
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Vector3Node.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/Vector3Node.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Numerics;
+using Windows.UI.Composition;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
 {
@@ -324,6 +326,74 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         }
 
         private Vector3 _value;
+
+        /// <summary>
+        /// Evaluates the current value of the expression
+        /// </summary>
+        /// <returns>The current value of the expression</returns>
+        public Vector3 Evaluate()
+        {
+            switch (NodeType)
+            {
+                case ExpressionNodeType.ConstantValue:
+                    return _value;
+                case ExpressionNodeType.ConstantParameter:
+                    throw new NotImplementedException();
+                case ExpressionNodeType.ReferenceProperty:
+                    var reference = (Children[0] as ReferenceNode).Reference;
+                    return PropertyName switch
+                    {
+                        nameof(Visual.Offset) => (reference as Visual).Offset,
+                        nameof(Visual.RotationAxis) => (reference as Visual).RotationAxis,
+                        nameof(Visual.CenterPoint) => (reference as Visual).CenterPoint,
+                        _ => GetProperty()
+                    };
+
+                    Vector3 GetProperty()
+                    {
+                        reference.Properties.TryGetVector3(PropertyName, out var value);
+                        return value;
+                    }
+
+                case ExpressionNodeType.Conditional:
+                    return
+                        (Children[0] as BooleanNode).Evaluate() ?
+                        (Children[1] as Vector3Node).Evaluate() :
+                        (Children[2] as Vector3Node).Evaluate();
+                case ExpressionNodeType.Add:
+                    return
+                        (Children[0] as Vector3Node).Evaluate() +
+                        (Children[1] as Vector3Node).Evaluate();
+                case ExpressionNodeType.Subtract:
+                    return
+                        (Children[0] as Vector3Node).Evaluate() -
+                        (Children[1] as Vector3Node).Evaluate();
+                case ExpressionNodeType.Negate:
+                    return
+                        -(Children[0] as Vector3Node).Evaluate();
+                case ExpressionNodeType.Multiply:
+                    return (Children[0], Children[1]) switch
+                    {
+                        (Vector3Node v1, Vector3Node v2) => v1.Evaluate() * v2.Evaluate(),
+                        (Vector3Node v1, ScalarNode s2) => v1.Evaluate() * s2.Evaluate(),
+                        (ScalarNode s1, Vector3Node v2) => s1.Evaluate() * v2.Evaluate(),
+                        _ => throw new NotImplementedException()
+                    };
+                case ExpressionNodeType.Divide:
+                    return
+                        (Children[0] as Vector3Node).Evaluate() /
+                        (Children[1] as Vector3Node).Evaluate();
+                case ExpressionNodeType.Vector3:
+                    return new Vector3(
+                        (Children[0] as ScalarNode).Evaluate(),
+                        (Children[1] as ScalarNode).Evaluate(),
+                        (Children[2] as ScalarNode).Evaluate());
+                case ExpressionNodeType.Swizzle:
+                    return new Vector3(Children[0].EvaluateSubchannel(Subchannels[0]), Children[0].EvaluateSubchannel(Subchannels[1]), Children[0].EvaluateSubchannel(Subchannels[2]));
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 #pragma warning restore CS0660, CS0661
 }

--- a/UnitTests/UnitTests.UWP/UI/Animations/Test_ExpressionNode.cs
+++ b/UnitTests/UnitTests.UWP/UI/Animations/Test_ExpressionNode.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Toolkit.Uwp;
+using Windows.UI.Xaml.Controls;
+using Microsoft.Toolkit.Uwp.UI.Animations;
+using System.Numerics;
+using Microsoft.Toolkit.Uwp.UI;
+using System;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Hosting;
+using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
+
+namespace UnitTests.UWP.UI.Animations
+{
+    [TestClass]
+    [TestCategory("Test_ExpressionNode")]
+    public class Test_ExpressionNode : VisualUITestBase
+    {
+        [TestMethod]
+        public async Task EvaluateExpressionNode()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                Grid grid = new();
+                await SetTestContentAsync(grid);
+
+                var visual = ElementCompositionPreview.GetElementVisual(grid);
+
+                // Test basic vector algebra
+                visual.Offset = Vector3.UnitX;
+                var vector3AlgebraNode = (-visual.GetReference().Offset
+                                    + Vector3.UnitY
+                                     - Vector3.UnitZ) * 5;
+
+                Assert.AreEqual(new Vector3(-5, 5, -5), vector3AlgebraNode.Evaluate());
+
+                // Test swizzle operation
+                visual.CenterPoint = Vector3.UnitY;
+                var swizzleNode = visual.GetReference().CenterPoint.GetSubchannels(
+                    Vector3Node.Subchannel.Y,
+                    Vector3Node.Subchannel.X,
+                    Vector3Node.Subchannel.Y);
+
+                Assert.AreEqual(new Vector3(1, 0, 1), swizzleNode.Evaluate());
+
+                // Test retrieving properties from set
+                var propertySet = visual.Compositor.CreatePropertySet();
+                var propertyName = "test";
+                var propertyNode = propertySet.GetReference().GetVector4Property(propertyName);
+
+                propertySet.InsertVector4(propertyName, Vector4.UnitW);
+                Assert.AreEqual(Vector4.UnitW, propertyNode.Evaluate());
+
+                propertySet.InsertVector4(propertyName, Vector4.UnitX);
+                Assert.AreEqual(Vector4.UnitX, propertyNode.Evaluate());
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -231,6 +231,7 @@
     <Compile Include="PrivateType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\Test_WeakEventListener.cs" />
+    <Compile Include="UI\Animations\Test_ExpressionNode.cs" />
     <Compile Include="UI\Animations\Test_AnimationBuilderStart.cs" />
     <Compile Include="UI\Collection\DataSource.cs" />
     <Compile Include="UI\Collection\Test_IncrementalLoadingCollection.cs" />


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

This PR contributes the Evaluate() method proposed in #4481 to evaluate the current value of any ExpresionNode at any given time (see discussion for rationale/usecases)

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
 - Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Currently consumers of the library can't get the current or hypothetical value of a ExpressionNode without running the animation, and even if they run it is hard to guarantee that the desired result is always returned (the user needs to read the value from the composition api at the right time, which is not always easy, and I've observed cases where the values are stale and haven't been updated by the composer yet).

## What is the new behavior?

This PR adds a method that evaluates it by traversing the expression tree. 
This doesn't alter the current logic/behavior, and the code introduced will only be executed if the consumer calls the Evaluate() method manually.

Also added a small test that verifies that a couple expression nodes evaluate to the right result.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
