### PR TITLE
Ryken100/attached card shadow composition mask brush resize fix

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -293,6 +293,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
             else
             {
                 base.SetElementChildVisual(context);
+
+                // Reset context.SpriteVisual.Size and RelativeSizeAdjustment to default values
+                // as they may be changed in the block above.
+                context.SpriteVisual.Size = Vector2.Zero;
+                context.SpriteVisual.RelativeSizeAdjustment = Vector2.One;
+
                 context.RemoveAndDisposeResource(OpacityMaskVisualSurfaceResourceKey);
                 context.RemoveAndDisposeResource(OpacityMaskSurfaceBrushResourceKey);
                 context.RemoveAndDisposeResource(OpacityMaskVisualResourceKey);
@@ -321,6 +327,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
             }
 
             UpdateShadowClip(context);
+            UpdateVisualOpacityMask(context);
 
             base.OnSizeChanged(context, newSize, previousSize);
         }

--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -326,6 +326,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
                 shapeVisual.Size = sizeAsVec2;
             }
 
+            if (context.TryGetResource(OpacityMaskVisualSurfaceResourceKey, out CompositionVisualSurface opacityMaskVisualSurface))
+            {
+                opacityMaskVisualSurface.SourceSize = sizeAsVec2 + new Vector2(MaxBlurRadius * 2);
+            }
+
+            if (InnerContentClipMode is InnerContentClipMode.CompositionMaskBrush)
+            {
+                context.SpriteVisual.Size = sizeAsVec2;
+            }
+
             UpdateShadowClip(context);
             UpdateVisualOpacityMask(context);
 

--- a/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Shadows/AttachedCardShadow.cs
@@ -305,20 +305,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
         {
             Vector2 sizeAsVec2 = newSize.ToVector2();
 
-            CompositionRoundedRectangleGeometry geometry = context.GetResource(RoundedRectangleGeometryResourceKey);
-            if (geometry != null)
+            if (context.TryGetResource(RoundedRectangleGeometryResourceKey, out CompositionRoundedRectangleGeometry geometry))
             {
                 geometry.Size = sizeAsVec2;
             }
 
-            CompositionVisualSurface visualSurface = context.GetResource(VisualSurfaceResourceKey);
-            if (geometry != null)
+            if (context.TryGetResource(VisualSurfaceResourceKey, out CompositionVisualSurface visualSurface))
             {
                 visualSurface.SourceSize = sizeAsVec2;
             }
 
-            ShapeVisual shapeVisual = context.GetResource(ShapeVisualResourceKey);
-            if (geometry != null)
+            if (context.TryGetResource(ShapeVisualResourceKey, out ShapeVisual shapeVisual))
             {
                 shapeVisual.Size = sizeAsVec2;
             }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4587

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

This PR fixes an issue where when `AttachedCardShadow.InnerContentClipType` is set to `CompositionMaskBrush`, the shadow doesn't properly resize when the element it's attached to changes size. It also fixes an issue where if `InnerContentClipType` is set to `CompositionMaskBrush` then back to `CompositionGeometricClip`, resizing gets broken in the `CompositionGeometricClip` mode as well.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

Bugfix

## What is the current behavior?

When `AttachedCardShadow.InnerContentClipType == CompositionMaskBrush`, the sizes of the masked `SpriteVisual`, and the `SpriteVisual` that owns the shadow were not updated when the attached `FrameworkElement` changes size. Additionally, `AttachedShadowElementContext.SpriteVisual.Size` and `RelativeSizeAdjustment` values were not reset to default when `InnerContentClipType` changed from `CompositionMaskBrush` to `CompositionGeometricClip`.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->

When `AttachedCardShadow.InnerContentClipType == CompositionMaskBrush`, the sizes of the masked `SpriteVisual`, and the `SpriteVisual` are now updated when the attached `FrameworkElement` changes size. Additionally, `AttachedShadowElementContext.SpriteVisual.Size` and `RelativeSizeAdjustment` are reset to default when `AttachedCardShadow.InnerContentClipType == CompositionGeometricClip`, preventing potential resize issues.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
