### PR TITLE
Add null check for ListDetailsView.OnListPaneWidthChanged

### DIFF
--- a/CommunityToolkit.WinUI.SampleApp/SamplePages/ListDetailsView/ListDetailsView.bind
+++ b/CommunityToolkit.WinUI.SampleApp/SamplePages/ListDetailsView/ListDetailsView.bind
@@ -11,7 +11,8 @@
         <controls:ListDetailsView BackButtonBehavior="Automatic"
                                     ItemsSource="{Binding Emails}"
                                     NoSelectionContent="Select an item to view"
-                                    CompactModeThresholdWidth="720">
+                                    CompactModeThresholdWidth="720"
+                                    ListPaneWidth="400">
             <controls:ListDetailsView.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Margin="0,8">

--- a/CommunityToolkit.WinUI.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -469,7 +469,10 @@ namespace CommunityToolkit.WinUI.UI.Controls
         /// </summary>
         private void OnListPaneWidthChanged()
         {
-            _twoPaneView.Pane1Length = new GridLength(ListPaneWidth);
+            if (_twoPaneView != null)
+            {
+                _twoPaneView.Pane1Length = new GridLength(ListPaneWidth);
+            }
         }
     }
 }


### PR DESCRIPTION
## Fixes

When I try to use the ListPaneWidth of ListDetailsView with WinUI3/WindowsAppSDK, I got the same error described in #4357 
It seems that the fix #4738 only fixed the issue in UWP and missed WinUI3

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type

What kind of change does this PR introduce?

Bugfix 

Refactoring 

## What is the current behavior?

`_TwoPaneView` passed without checking for null

## What is the new behavior?

It will check if `_twoPaneView` is null, and set value to `_twoPaneView.Pane1Length` only when it's not null.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
