### PR TITLE
Fix several DataGrid theme issues

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -448,7 +448,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             this.DefaultStyleKey = typeof(DataGrid);
 
+            ActualThemeChanged += this.DataGrid_ActualThemeChanged;
+
             HookDataGridEvents();
+        }
+
+        private void DataGrid_ActualThemeChanged(FrameworkElement sender, object args)
+        {
+            DataGrid dataGrid = sender as DataGrid;
+            foreach (DataGridRow row in dataGrid.GetAllRows())
+            {
+                row.EnsureBackground();
+                row.EnsureForeground();
+            }
         }
 
         /// <summary>
@@ -5890,6 +5902,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             _showingMouseIndicators = false;
             _keepScrollBarsShowing = false;
+
+            ActualThemeChanged -= this.DataGrid_ActualThemeChanged;
         }
 
 #if FEATURE_VALIDATION

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.xaml
@@ -32,6 +32,7 @@
             <StaticResource x:Key="DataGridRowGroupHeaderPressedBackgroundBrush" ResourceKey="SystemControlBackgroundListMediumBrush"/>
             <StaticResource x:Key="DataGridRowGroupHeaderForegroundBrush" ResourceKey="SystemControlForegroundBaseHighBrush"/>
             <StaticResource x:Key="DataGridRowHoveredBackgroundColor" ResourceKey="SystemListLowColor"/>
+            <StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="InvalidBrush" Color="#FFFF00"/>
@@ -49,6 +50,7 @@
             <StaticResource x:Key="DataGridRowGroupHeaderPressedBackgroundBrush" ResourceKey="SystemControlBackgroundListMediumBrush"/>
             <StaticResource x:Key="DataGridRowGroupHeaderForegroundBrush" ResourceKey="SystemControlForegroundBaseHighBrush"/>
             <StaticResource x:Key="DataGridRowHoveredBackgroundColor" ResourceKey="SystemListLowColor"/>
+            <StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="InvalidBrush" Color="#C50500"/>
@@ -66,6 +68,7 @@
             <StaticResource x:Key="DataGridRowGroupHeaderPressedBackgroundBrush" ResourceKey="SystemControlBackgroundListMediumBrush"/>
             <StaticResource x:Key="DataGridRowGroupHeaderForegroundBrush" ResourceKey="SystemControlForegroundBaseHighBrush"/>
             <StaticResource x:Key="DataGridRowHoveredBackgroundColor" ResourceKey="SystemListLowColor"/>
+            <StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -91,7 +94,6 @@
 
     <StaticResource x:Key="GridLinesBrush" ResourceKey="SystemControlGridLinesBaseMediumLowBrush"/>
 
-    <StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
     <StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="FillerGridLinesBrush"/>
     <StaticResource x:Key="DataGridRowSelectedBackgroundColor" ResourceKey="SystemAccentColor"/>
     <StaticResource x:Key="DataGridRowSelectedBackgroundOpacity" ResourceKey="ListAccentLowOpacity"/>


### PR DESCRIPTION
## Fixes #3305

The DataGrid fails to update colors of rows and row details when the theme changes. Issue #3305 covers the row details problem. The row colors problem does not have an issue filed against it but it's a related problem.

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Current behavior is as described in issue #3305. Specifically, row colors and row detail colors do not update when the theme is changed.

## What is the new behavior?

Now, when the theme is changed, row colors and row details colors are updated appropriately.

## PR Checklist

Please check if your PR fulfills the following requirements: 

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes

## Other information

I can't get the GridSplitter tests to run, but they shouldn't be relevant to nor affected by these changes.
