### PR TITLE
[TokenizingTextBox] Keep text after a query is submitted

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.Properties.cs
@@ -117,6 +117,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Identifies the <see cref="KeepTextAfterQuerySubmitted"/> property.
+        /// </summary>
+        public static readonly DependencyProperty KeepTextAfterQuerySubmittedProperty = DependencyProperty.Register(
+            nameof(KeepTextAfterQuerySubmitted),
+            typeof(bool),
+            typeof(TokenizingTextBox),
+            new PropertyMetadata(false));
+
+
+        /// <summary>
         /// Identifies the <see cref="SuggestedItemsSource"/> property.
         /// </summary>
         public static readonly DependencyProperty SuggestedItemsSourceProperty = DependencyProperty.Register(
@@ -280,6 +290,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get => (string)GetValue(TextProperty);
             set => SetValue(TextProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the control should keep or clear the text
+        /// after the query is submitted. Default is false (to clear the text).
+        /// </summary>
+        public bool KeepTextAfterQuerySubmitted
+        {
+            get => (bool)GetValue(KeepTextAfterQuerySubmittedProperty);
+            set => SetValue(KeepTextAfterQuerySubmittedProperty, value);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
@@ -153,8 +153,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (chosenItem != null)
             {
                 await Owner.AddTokenAsync(chosenItem); // TODO: Need to pass index?
-                sender.Text = string.Empty;
-                Owner.Text = string.Empty;
+                if (!Owner.KeepTextAfterQuerySubmitted)
+                {
+                    sender.Text = string.Empty;
+                    Owner.Text = string.Empty;
+                }
+
                 sender.Focus(FocusState.Programmatic);
             }
         }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4917
<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Add the ability (via a XAML bool property) to keep the typed text after a QuerySubmitted event finishes. This will make the TTB useful in an 'advanced search' scenario when the user selects tokens from a list that help narrow the search criteria to a certain sub-domain (for example to search only through a certain field or several fields if more tokens are selected). 

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the TTB deletes the entered text after a submit is made (either by pressing enter or by selecting a proposed token). 

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
By adding the KeepTextAfterQuerySubmitted property to the XAML and setting it to true you can modify the behavior to keep the typed text inside the text box after submitting it. The proposed solution is backward compatible as the property defaults to "false" (behaves like it currently does).

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [ ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
