### PR TITLE
Fix DoubleToObjectConverter with GreaterThan and LessThan set

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Converters/DoubleToObjectConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Converters/DoubleToObjectConverter.cs
@@ -119,16 +119,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
 
             var boolValue = false;
 
-            if (GreaterThan != double.NaN && LessThan != double.NaN &&
-                vd > GreaterThan && vd < LessThan)
+            if (!double.IsNaN(GreaterThan) && !double.IsNaN(LessThan))
+            {
+                if (vd > GreaterThan && vd < LessThan)
+                {
+                    boolValue = true;
+                }
+            }
+            else if (!double.IsNaN(GreaterThan) && vd > GreaterThan)
             {
                 boolValue = true;
             }
-            else if (GreaterThan != double.NaN && vd > GreaterThan)
-            {
-                boolValue = true;
-            }
-            else if (LessThan != double.NaN && vd < LessThan)
+            else if (!double.IsNaN(LessThan) && vd < LessThan)
             {
                 boolValue = true;
             }

--- a/UnitTests/UnitTests.UWP/Converters/Test_DoubleToObjectConverter.cs
+++ b/UnitTests/UnitTests.UWP/Converters/Test_DoubleToObjectConverter.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Toolkit.Uwp.UI.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.UI.Xaml;
+
+namespace UnitTests.Converters
+{
+    [TestClass]
+    public class Test_DoubleToObjectConverter
+    {
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_LessThan_Visible()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                LessThan = 1.0,
+            };
+            var result = converter.Convert(0.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Visible, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_LessThan_Collapsed()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                LessThan = 1.0,
+            };
+            var result = converter.Convert(1.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Collapsed, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_GreaterThan_Visible()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                GreaterThan = 1.0,
+            };
+            var result = converter.Convert(1.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Visible, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_GreaterThan_Collapsed()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                GreaterThan = 1.0,
+            };
+            var result = converter.Convert(0.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Collapsed, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_GreaterLessThan_Visible()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                GreaterThan = 1.0,
+                LessThan = 2.0,
+            };
+            var result = converter.Convert(1.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Visible, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_GreaterLessThan_ValueGreater_Collapsed()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                GreaterThan = 1.0,
+                LessThan = 2.0,
+            };
+            var result = converter.Convert(2.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Collapsed, result);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Test_DoubleToVisibilityConverter_GreaterLessThan_ValueLess_Collapsed()
+        {
+            var converter = new DoubleToObjectConverter
+            {
+                TrueValue = Visibility.Visible,
+                FalseValue = Visibility.Collapsed,
+                GreaterThan = 1.0,
+                LessThan = 2.0,
+            };
+            var result = converter.Convert(0.5, typeof(Visibility), null, "en-us");
+            Assert.AreEqual(Visibility.Collapsed, result);
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -164,6 +164,7 @@
     </Compile>
     <Compile Include="Behaviors\Test_AutoSelectBehavior.cs" />
     <Compile Include="Converters\Test_AdaptiveHeightValueConverter.cs" />
+    <Compile Include="Converters\Test_DoubleToObjectConverter.cs" />
     <Compile Include="Converters\Test_TaskResultConverter.cs" />
     <Compile Include="Converters\Test_BoolToObjectConverter.cs" />
     <Compile Include="Converters\Test_EmptyCollectionToObjectConverter.cs" />


### PR DESCRIPTION
## Fixes

`DoubleToObjectConverter` not working as expected when `GreaterThan` and `LessThan` are both set

## PR Type

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4854

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->

Fixed the wrong code in the converter and added tests.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
